### PR TITLE
'render :update do page' pattern is broken

### DIFF
--- a/lib/comfortable_mexican_sofa/controller_methods.rb
+++ b/lib/comfortable_mexican_sofa/controller_methods.rb
@@ -21,7 +21,7 @@ module ComfortableMexicanSofa::ControllerMethods
   # instance variables that can be used in partials (that are included by
   # by the cms page and/or layout)
   def render_with_cms(options = {}, locals = {}, &block)
-    if (path = options.delete(:cms_page)) rescue false
+    if options.class == Hash && path = options.delete(:cms_page)
       site = CmsSite.find_by_hostname(request.host.downcase)
       page = CmsPage.load_from_file(site, path) if site && ComfortableMexicanSofa.configuration.seed_data_path
       page ||= site && site.cms_pages.find_by_full_path(path)


### PR DESCRIPTION
Because module ComfortableMexicanSofa::ControllerMethods aliases the render method but doesn't handle when render's argument isn't a Hash it breaks the render pattern:

```
    render :update do |page| 
       ....
    end
```

While the rails app should use rjs templates, etc, such is life when working with a large legacy codebases.

A simple fix is to test for options being a Hash, otherwise render_without_cms, etc.
