### PR TITLE
Added an underscore version of slugify, for snippet slugs

### DIFF
--- a/app/views/cms_admin/snippets/_form.html.erb
+++ b/app/views/cms_admin/snippets/_form.html.erb
@@ -3,5 +3,5 @@
 <% end %>
 
 <%= form.text_field :label, :id => (@cms_snippet.new_record?? 'slugify' : nil) %>
-<%= form.text_field :slug, :id => 'slug' %>
+<%= form.text_field :slug, :id => 'slug', :class => 'delimiter-underscore' %>
 <%= form.text_area :content, :class => 'code' %>

--- a/public/javascripts/comfortable_mexican_sofa/cms.js
+++ b/public/javascripts/comfortable_mexican_sofa/cms.js
@@ -31,17 +31,23 @@ $.CMS = function(){
     
     slugify: function(){
       $('input#slugify').bind('keyup.cms', function() {
-        $('input#slug').val( slugify( $(this).val() ) );
+        var slug_input = $('input#slug');
+        var delimiter = slug_input.hasClass('delimiter-underscore') ? '_' : '-';
+        slug_input.val( slugify( $(this).val(), delimiter ) );
       });
-      
-      function slugify(str){
+
+      function slugify(str, delimiter){
+        var opposite_delimiter = (delimiter == '-') ? '_' : '-';
         str = str.replace(/^\s+|\s+$/g, '');
-        var from = "ÀÁÄÂÈÉËÊÌÍÏÎÒÓÖÔÙÚÜÛàáäâèéëêìíïîòóöôùúüûÑñÇç·/_,:;";
-        var to   = "aaaaeeeeiiiioooouuuuaaaaeeeeiiiioooouuuunncc------";
+        var from = "ÀÁÄÂÈÉËÊÌÍÏÎÒÓÖÔÙÚÜÛàáäâèéëêìíïîòóöôùúüûÑñÇç";
+        var to   = "aaaaeeeeiiiioooouuuuaaaaeeeeiiiioooouuuunncc";
         for (var i=0, l=from.length ; i<l ; i++) {
           str = str.replace(new RegExp(from[i], "g"), to[i]);
         }
-        str = str.replace(/[^a-zA-Z0-9 -]/g, '').replace(/\s+/g, '-').toLowerCase();
+        var chars_to_replace_with_delimiter = new RegExp('[·/,:;'+ opposite_delimiter +']', 'g');
+        str = str.replace(chars_to_replace_with_delimiter, delimiter);
+        var chars_to_remove = new RegExp('[^a-zA-Z0-9 '+ delimiter +']', 'g');
+        str = str.replace(chars_to_remove, '').replace(/\s+/g, delimiter).toLowerCase();
         return str;
       }
     },


### PR DESCRIPTION
The documentation for snippets uses a symbol with underscores separating words e.g. ":snippet_slug". When creating a new snippet it is little confusing because the javascript will generate the slug with dashes instead. While this behavior makes sense for the rest of the slugs used in CMS, it would be more convenient for newcomers to have it be generated with underscores. This patch sets the default delimiter of slugify to dashes, while using underscores is as simple as adding a class of delimiter-underscore to the input#slug element. 
