### PR TITLE
Add paperclip options to the CmsUpload model

### DIFF
--- a/app/models/cms_upload.rb
+++ b/app/models/cms_upload.rb
@@ -1,7 +1,7 @@
 class CmsUpload < ActiveRecord::Base
 
   # -- AR Extensions --------------------------------------------------------
-  has_attached_file :file
+  has_attached_file :file, ComfortableMexicanSofa.config.upload_file_options
   
   # -- Relationships --------------------------------------------------------
   belongs_to :cms_site

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -31,7 +31,12 @@ ComfortableMexicanSofa.configure do |config|
   # page caching for CMS Layout CSS and Javascript. Enabled by default. When deploying
   # to an environment with read-only filesystem (like Heroku) turn this setting off.
   #   config.enable_caching = true
-  
+
+  # File uploads use Paperclip and can support filesystem or s3 uploads.  Override
+  # the upload method and appropriate settings based on Paperclip.  For S3 see:
+  # http://rdoc.info/gems/paperclip/2.3.8/Paperclip/Storage/S3, and for 
+  # filesystem see: http://rdoc.info/gems/paperclip/2.3.8/Paperclip/Storage/S3
+  #   config.upload_file_options = {:storage => :filesystem}
 end
 
 # Default credentials for ComfortableMexicanSofa::HttpAuth

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -26,6 +26,9 @@ class ComfortableMexicanSofa::Configuration
   
   # Caching for css/js. For admin layout and ones for cms content. Enabled by default.
   attr_accessor :enable_caching
+
+  # Upload settings
+  attr_accessor :upload_file_options
   
   # Configuration defaults
   def initialize
@@ -37,6 +40,7 @@ class ComfortableMexicanSofa::Configuration
     @auto_manage_sites    = true
     @disable_irb          = true
     @enable_caching       = true
+    @upload_file_options  = {}
   end
   
 end


### PR DESCRIPTION
I'm resubmitting this since I messed up my original pull request.

twg: you suggested overriding Paperclip's global defaults to assign options for the CMS.  This feels very wrong to me.  I've got many different locations within my app that use Paperclip and each of them have different styles but a common base of options.  These don't necessarily match with what my CMS should have.  Monkey patching the global default forces me to override the CmsUpload options on every other place in my app.  That's asking a lot of the developer who is pulling in this engine to add a simple CMs to their site.

Consider this the followup to your original comment on https://github.com/twg/comfortable-mexican-sofa/pull/17
