### PR TITLE
Over-ride site host

### DIFF
--- a/app/controllers/cms_admin/base_controller.rb
+++ b/app/controllers/cms_admin/base_controller.rb
@@ -13,16 +13,17 @@ class CmsAdmin::BaseController < ActionController::Base
 protected
   
   def load_admin_cms_site
-    @cms_site = CmsSite.find_by_hostname!(request.host.downcase)
+    hostname = ComfortableMexicanSofa.config.override_host || request.host.downcase
+    @cms_site = CmsSite.find_by_hostname!(hostname)
   
   rescue ActiveRecord::RecordNotFound
     
     if ComfortableMexicanSofa.config.auto_manage_sites
       if CmsSite.count == 0
-        @cms_site = CmsSite.create!(:label => 'Default Site', :hostname => request.host.downcase)
+        @cms_site = CmsSite.create!(:label => 'Default Site', :hostname => hostname)
       elsif CmsSite.count == 1
         @cms_site = CmsSite.first
-        @cms_site.update_attribute(:hostname, request.host.downcase)
+        @cms_site.update_attribute(:hostname, hostname)
       end
     end
     

--- a/app/controllers/cms_content_controller.rb
+++ b/app/controllers/cms_content_controller.rb
@@ -22,7 +22,7 @@ class CmsContentController < ApplicationController
 protected
   
   def load_cms_site
-    @cms_site = CmsSite.find_by_hostname!(request.host.downcase)
+    @cms_site = CmsSite.find_by_hostname!(ComfortableMexicanSofa.config.override_host || request.host.downcase)
   rescue ActiveRecord::RecordNotFound
     render :text => 'Site Not Found', :status => 404
   end

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -31,7 +31,12 @@ ComfortableMexicanSofa.configure do |config|
   # page caching for CMS Layout CSS and Javascript. Enabled by default. When deploying
   # to an environment with read-only filesystem (like Heroku) turn this setting off.
   #   config.enable_caching = true
-  
+
+  # Override the host used to look up the active CmsSite.  If you are not
+  # planning on using the site features, I recommend you set this override to
+  # limit unexpected "Site not found" errors when you try to hit app01.example.com
+  # instead of www.example.com.
+  #   config.override_host = "www.exmample.com"
 end
 
 # Default credentials for ComfortableMexicanSofa::HttpAuth

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -26,6 +26,12 @@ class ComfortableMexicanSofa::Configuration
   
   # Caching for css/js. For admin layout and ones for cms content. Enabled by default.
   attr_accessor :enable_caching
+
+  # Upload settings
+  attr_accessor :upload_file_options
+
+  # Override the hostname when looking up which site to use
+  attr_accessor :override_host
   
   # Configuration defaults
   def initialize
@@ -37,6 +43,8 @@ class ComfortableMexicanSofa::Configuration
     @auto_manage_sites    = true
     @disable_irb          = true
     @enable_caching       = true
+    @upload_file_options  = {}
+    @override_host        = nil
   end
   
 end


### PR DESCRIPTION
We aren't managing more than a single site with CMS.  In order to deal with problems around our different hostnames in rspec, cucumber, development, staging and production I've added an over-ride that forces the hostname that is looked up in CmsSite to a fixed string.  This means that with this option set, you will be pulling pages from the same site no matter what hostname is actually used in the request.

I think eventually I'd like to change this or add a toggle to it for disabling sites completely since we make a lookup in the DB on every request.
