### PR TITLE
Add config.cms_content_route_prefix

### DIFF
--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -10,6 +10,10 @@ ComfortableMexicanSofa.configure do |config|
   # You can change 'cms-admin' to 'admin', for example.
   #   config.admin_route_prefix = 'cms-admin'
   
+  # Default url to content directly is http://yourhost/
+  # You can change '' to 'preview', for example.
+  #   config.cms_content_route_prefix = ''
+  
   # Path: /cms-admin redirects to /cms-admin/pages but you can change it
   # You don't need to change it when changing admin_route_prefix
   #   config.admin_route_redirect = '/cms-admin/pages'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,9 +18,10 @@ Rails.application.routes.draw do
   end
   
   scope :controller => :cms_content do
-    get '/cms-css/:id'  => :render_css,   :as => 'cms_css'
-    get '/cms-js/:id'   => :render_js,    :as => 'cms_js'
-    get '/'             => :render_html,  :as => 'cms_html',  :path => '(*cms_path)'
+    prefix = ComfortableMexicanSofa.config.cms_content_route_prefix
+    get "#{prefix}/cms-css/:id"  => :render_css,   :as => 'cms_css'
+    get "#{prefix}/cms-js/:id"   => :render_js,    :as => 'cms_js'
+    get "#{prefix}/"             => :render_html,  :as => 'cms_html',  :path => "#{prefix}/(*cms_path)"
   end
   
 end

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -14,6 +14,10 @@ class ComfortableMexicanSofa::Configuration
   # You can change 'cms-admin' to 'admin', for example.
   attr_accessor :admin_route_prefix
   
+  # Default url to content directly is http://yourhost/
+  # You can change '' to 'preview', for example.
+  attr_accessor :cms_content_route_prefix
+  
   # /cms-admin redirects to /cms-admin/pages but you can change it
   # to something else
   attr_accessor :admin_route_redirect
@@ -39,6 +43,7 @@ class ComfortableMexicanSofa::Configuration
     @authentication       = 'ComfortableMexicanSofa::HttpAuth'
     @seed_data_path       = nil
     @admin_route_prefix   = 'cms-admin'
+    @cms_content_route_prefix = ''
     @admin_route_redirect = "/#{@admin_route_prefix}/pages"
     @auto_manage_sites    = true
     @disable_irb          = true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,7 @@ class ActiveSupport::TestCase
       config.authentication       = 'ComfortableMexicanSofa::HttpAuth'
       config.seed_data_path       = nil
       config.admin_route_prefix   = 'cms-admin'
+      config.cms_content_route_prefix = ''
       config.admin_route_redirect = "/cms-admin/pages"
       config.auto_manage_sites    = true
       config.disable_irb          = true

--- a/test/unit/cms_configuration_test.rb
+++ b/test/unit/cms_configuration_test.rb
@@ -8,6 +8,7 @@ class CmsConfigurationTest < ActiveSupport::TestCase
     assert_equal 'ComfortableMexicanSofa::HttpAuth', config.authentication
     assert_equal nil, config.seed_data_path
     assert_equal 'cms-admin', config.admin_route_prefix
+    assert_equal '', config.cms_content_route_prefix
     assert_equal '/cms-admin/pages', config.admin_route_redirect
     assert_equal true, config.disable_irb
     assert_equal true, config.enable_caching


### PR DESCRIPTION
For app integration, allow override router prefix for viewing CMS content.
