### PR TITLE
Inherit from ApplicationController instead of ActionController::Base.

### DIFF
--- a/app/controllers/cms_admin/base_controller.rb
+++ b/app/controllers/cms_admin/base_controller.rb
@@ -1,4 +1,4 @@
-class CmsAdmin::BaseController < ActionController::Base
+class CmsAdmin::BaseController < ApplicationController
   
   protect_from_forgery
   


### PR DESCRIPTION
Will allow the CMS admin to inherit authentication or authorization logic that has been placed into ApplicationController by the parent application.
