### PR TITLE
Fix javascript when using custom nested admin routes

### DIFF
--- a/app/views/layouts/cms_admin/_head.html.erb
+++ b/app/views/layouts/cms_admin/_head.html.erb
@@ -2,6 +2,7 @@
   <meta http-equiv="Content-type" content="text/html; charset=utf-8">
   <title><%= ComfortableMexicanSofa.config.cms_title %></title>
   <%= csrf_meta_tag %>
+  <meta name="cms-admin-path" content="<%= ComfortableMexicanSofa.config.admin_route_prefix %>" />
   <%= stylesheet_link_tag :cms, :cache => ('_cms' if ComfortableMexicanSofa.config.enable_caching) %>
   <%= javascript_include_tag :cms, :cache => ('_cms' if ComfortableMexicanSofa.config.enable_caching) %>
   <%= javascript_include_tag :tiny_mce %>

--- a/public/javascripts/comfortable_mexican_sofa/cms.js
+++ b/public/javascripts/comfortable_mexican_sofa/cms.js
@@ -1,9 +1,9 @@
 $.CMS = function(){
   var current_path = window.location.pathname;
-  var admin_path_prefix = current_path.split('/')[1]
-  
+  var admin_path_prefix = $('meta[name="cms-admin-path"]').attr('content');
+
   $(function(){
-    
+
     $.CMS.slugify();
     $.CMS.tree_methods();
     $.CMS.load_page_blocks();
@@ -16,9 +16,9 @@ $.CMS = function(){
     if($('#page_save').get(0))        $.CMS.enable_page_save_widget();
     if($('#uploader_button').get(0))  $.CMS.enable_uploader();
   });
-  
+
   return {
-    
+
     enable_sortable_list: function(){
       $('ul.sortable, ul.sortable ul').sortable({
         handle: 'div.dragger',
@@ -28,7 +28,7 @@ $.CMS = function(){
         }
       })
     },
-    
+
     slugify: function(){
       $('input#slugify').bind('keyup.cms', function() {
         var slug_input = $('input#slug');
@@ -51,7 +51,7 @@ $.CMS = function(){
         return str;
       }
     },
-    
+
     // Load Page Blocks on layout change
     load_page_blocks: function(){
       $('select#cms_page_layout_id').bind('change.cms', function() {
@@ -60,14 +60,14 @@ $.CMS = function(){
           data: ({
             layout_id: $(this).val()
           }),
-          complete: function(){ 
+          complete: function(){
             $.CMS.enable_rich_text();
             $.CMS.enable_date_picker();
           }
         })
       });
     },
-    
+
     enable_rich_text: function(){
       $('textarea.rich_text').tinymce({
          theme : "advanced",
@@ -83,7 +83,7 @@ $.CMS = function(){
          theme_advanced_resize_horizontal : false
        });
     },
-    
+
     enable_codemirror: function(){
       $('textarea.code').each(function(i, element){
         CodeMirror.fromTextArea(element, {
@@ -97,7 +97,7 @@ $.CMS = function(){
           stylesheet: "/javascripts/comfortable_mexican_sofa/codemirror/codemirror.css"
         });
       });
-      
+
       $('textarea.code_css').each(function(i, element){
         CodeMirror.fromTextArea(element, {
           basefiles: [
@@ -107,7 +107,7 @@ $.CMS = function(){
           stylesheet: "/javascripts/comfortable_mexican_sofa/codemirror/codemirror.css"
         });
       });
-      
+
       $('textarea.code_js').each(function(i, element){
         CodeMirror.fromTextArea(element, {
           basefiles: [
@@ -118,18 +118,18 @@ $.CMS = function(){
         });
       });
     },
-    
+
     enable_date_picker: function(){
       $('input[type=datetime]').datepicker();
     },
-    
+
     enable_desc_toggle: function(){
       $('.form_element .desc .desc_toggle').click(function(){
         $(this).toggle();
         $(this).siblings('.desc_content').toggle();
       })
     },
-    
+
     tree_methods: function(){
       $('a.tree_toggle').bind('click.cms', function() {
         $(this).siblings('ul').toggle();
@@ -137,7 +137,7 @@ $.CMS = function(){
         // object_id are set in the helper (check cms_helper.rb)
         $.ajax({url: [current_path, object_id, 'toggle'].join('/')});
       });
-      
+
       $('ul.sortable').each(function(){
         $(this).sortable({
           handle: 'div.dragger',
@@ -148,11 +148,11 @@ $.CMS = function(){
         })
       });
     },
-    
+
     enable_page_save_widget : function(){
       $('#page_save input').attr('checked', $('input#cms_page_is_published').is(':checked'));
       $('#page_save button').html($('input#cms_page_submit').val());
-      
+
       $('#page_save input').bind('click', function(){
         $('input#cms_page_is_published').attr('checked', $(this).is(':checked'));
       })
@@ -163,7 +163,7 @@ $.CMS = function(){
         $('input#cms_page_submit').click();
       })
     },
-    
+
     enable_page_save_form : function(){
       $('input[name=commit]').click(function() {
         $(this).parents('form').attr('target', '');
@@ -172,7 +172,7 @@ $.CMS = function(){
         $(this).parents('form').attr('target', '_blank');
       });
     },
-    
+
     enable_uploader : function(){
       auth_token = $("meta[name=csrf-token]").attr('content');
       var uploader = new plupload.Uploader({


### PR DESCRIPTION
When using a nested admin route prefix (`admin/cms` in my case) the uploads fail because is trying to post to `/admin/uploads`

This fix the problem and expose the exact configuration value to javascript using the same technique as the rails csrf token.  
