### PR TITLE
multiple language routes

### DIFF
--- a/app/controllers/cms_content_controller.rb
+++ b/app/controllers/cms_content_controller.rb
@@ -41,7 +41,12 @@ protected
   end
   
   def load_cms_page
-    @cms_page = @cms_site.pages.published.find_by_full_path!("/#{params[:cms_path]}")
+    cms_path = if ComfortableMexicanSofa.config.enable_multiple_language_routes
+      "/#{params[:locale]}/#{params[:cms_path]}".sub!(/\/$/,'')
+    else
+      "/#{params[:cms_path]}"
+    end
+    @cms_page = @cms_site.pages.published.find_by_full_path!(cms_path)
     return redirect_to(@cms_page.target_page.full_path) if @cms_page.target_page
     
   rescue ActiveRecord::RecordNotFound

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -51,6 +51,15 @@ ComfortableMexicanSofa.configure do |config|
   # a previous version using this system. You can control how many revisions per
   # object you want to keep. Set it to 0 if you wish to turn this feature off.
   #   config.revisions_limit = 25
+
+  # In case you want to use :locale to I18n your content within one site, it will
+  # need to do some routing changes. This will enable urls like "https://www.example.com/en"
+  # and "https://www.example.com/fr" to live in the same site. Default is false.
+  #   config.enable_multiple_language_routes = false
+  
+  # Additionaly if enable_multiple_language_routes is activated we need to define a
+  # default locale to use in case no locale was requested. Defaults to "en".
+  #   config.default_locale = "en"
   
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,13 @@ Rails.application.routes.draw do
     prefix = ComfortableMexicanSofa.config.content_route_prefix
     get "#{prefix}/cms-css/:id"  => :render_css,   :as => 'cms_css'
     get "#{prefix}/cms-js/:id"   => :render_js,    :as => 'cms_js'
-    get "#{prefix}/"             => :render_html,  :as => 'cms_html',  :path => "#{prefix}/(*cms_path)"
+    if ComfortableMexicanSofa.config.enable_multiple_language_routes and ComfortableMexicanSofa.config.default_locale
+      default_locale=ComfortableMexicanSofa.config.default_locale
+      get ":locale/#{prefix}/"   => :render_html,  :as => 'cms_html',  :path => ":locale/#{prefix}/(*cms_path)"
+      get "#{prefix}/"           => redirect("/#{default_locale}/#{prefix}")
+    else
+      get "#{prefix}/"     => :render_html,  :as => 'cms_html',  :path => "#{prefix}/(*cms_path)"
+    end
   end
   
 end

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -40,6 +40,12 @@ class ComfortableMexicanSofa::Configuration
   # Number of revisions kept. Default is 25. If you wish to disable: set this to 0.
   attr_accessor :revisions_limit
   
+  # Enable multiple languages in a site via route (i.e. http://www.example.com/en, http://www.example.com/fr)
+  attr_accessor :enable_multiple_language_routes
+  
+  # To which locale should non-locale routes be redirected?
+  attr_accessor :default_locale
+  
   # Configuration defaults
   def initialize
     @cms_title              = 'ComfortableMexicanSofa MicroCMS'
@@ -55,6 +61,8 @@ class ComfortableMexicanSofa::Configuration
     @enable_fixtures        = false
     @fixtures_path          = File.expand_path('db/cms_fixtures', Rails.root)
     @revisions_limit        = 25
+    @enable_multiple_language_routes = false
+    @default_locale         = "en"
   end
   
 end


### PR DESCRIPTION
Hi,
   i did some small changes to use locales in routes for I18n of the content. Feel free to pull it or reject it.

   It adds 2 configuration options:
- enable_multiple_language_routes: Enables the feature (Default:false)
- default_locale: Sets the default locale when user doesn't request one (Default: en)
  
  Enabling this feature creates the routes that are needed to have I18n of the content using urls like:
  http://www.example.com/en
  http://www.example.com/fr
  
  This also sets the params[:locale] parameter on request which can be used for setting the I18n.locale

Cheers,
Christos
