### PR TITLE
Add link_to tag. Supports {{cms:link_to:Link title:slug}} or {{cms:link_t

### DIFF
--- a/lib/comfortable_mexican_sofa/tags/link_to.rb
+++ b/lib/comfortable_mexican_sofa/tags/link_to.rb
@@ -1,0 +1,20 @@
+class ComfortableMexicanSofa::Tag::LinkTo
+  include ComfortableMexicanSofa::Tag
+
+  def self.regex_tag_signature(label = nil)
+    label ||= /[^:]+/
+    /\{\{\s*cms:link_to:(#{label}):?(.*?)\s*\}\}/
+  end
+
+  def content
+    ps = params.split(':')
+    path = ps.first
+    unless path =~ /\//
+      slug = path
+      target_page = page.site.pages.published.find_by_slug(slug)
+      return nil unless target_page.present?
+      path = ComfortableMexicanSofa.config.content_route_prefix + target_page.full_path
+    end
+    "<a href=\"#{path}\">#{label}</a>"
+  end
+end

--- a/test/unit/tags/link_to_test.rb
+++ b/test/unit/tags/link_to_test.rb
@@ -1,0 +1,57 @@
+require File.expand_path('../../test_helper', File.dirname(__FILE__))
+
+class LinkToTest < ActiveSupport::TestCase
+  
+  def test_initialize_tag
+    assert tag = ComfortableMexicanSofa::Tag::LinkTo.initialize_tag(
+      cms_pages(:default), '{{ cms:link_to:label:slug }}'
+    )
+    assert_equal 'label', tag.label
+    assert tag = ComfortableMexicanSofa::Tag::LinkTo.initialize_tag(
+      cms_pages(:default), '{{ cms:link_to:Label with Spaces:slug }}'
+    )
+    assert_equal 'Label with Spaces', tag.label
+    assert tag = ComfortableMexicanSofa::Tag::LinkTo.initialize_tag(
+      cms_pages(:default), '{{cms:link_to:label:/path}}'
+    )
+    assert_equal 'label', tag.label
+  end
+  
+  def test_initialize_tag_failure
+    [
+      '{{cms:link_to}}',
+      '{{cms:not_link_to:label:slug}}',
+      '{not_a_tag}'
+    ].each do |tag_signature|
+      assert_nil ComfortableMexicanSofa::Tag::LinkTo.initialize_tag(
+        cms_pages(:default), tag_signature
+      )
+    end
+  end
+  
+  def test_content_and_render
+    tag = ComfortableMexicanSofa::Tag::LinkTo.initialize_tag(
+      cms_pages(:default), '{{cms:link_to:My Link:}}'
+    )
+    assert_equal '<a href="/">My Link</a>', tag.content
+    assert_equal '<a href="/">My Link</a>', tag.render
+    
+    tag = ComfortableMexicanSofa::Tag::LinkTo.initialize_tag(
+      cms_pages(:default), '{{cms:link_to:My Link:child-page}}'
+    )
+    assert_equal '<a href="/child-page">My Link</a>', tag.content
+    assert_equal '<a href="/child-page">My Link</a>', tag.render
+    
+    tag = ComfortableMexicanSofa::Tag::LinkTo.initialize_tag(
+      cms_pages(:default), '{{cms:link_to:My Link:/path}}'
+    )
+    assert_equal '<a href="/path">My Link</a>', tag.content
+    assert_equal '<a href="/path">My Link</a>', tag.render
+    
+    tag = ComfortableMexicanSofa::Tag::LinkTo.initialize_tag(
+      cms_pages(:default), "{{cms:link_to:Does not exist:doesnot_exist}}"
+    )
+    assert_equal nil, tag.content
+    assert_equal '', tag.render
+  end
+end


### PR DESCRIPTION
Add link_to tag. Supports {{cms:link_to:Link title:slug}} or {{cms:link_to:Link title:/full/path}}.
Takes content_route_prefix into account when generating paths from slugs.
