### PR TITLE
javascript assets paths broken

### DIFF
--- a/app/views/layouts/cms_admin/_head.html.erb
+++ b/app/views/layouts/cms_admin/_head.html.erb
@@ -5,7 +5,7 @@
   
   <meta name="cms-admin-path" content="<%= ComfortableMexicanSofa.config.admin_route_prefix %>" />
   <meta name="cms-locale" content="<%= I18n.locale %>" />
-  <meta name="cms-js-assets-base-path" content="<%= ComfortableMexicanSofa.asset_pipeline_enabled?? '/assets' : '/public/javascripts' %>/comfortable_mexican_sofa"/>
+  <meta name="cms-js-assets-base-path" content="<%= ComfortableMexicanSofa.asset_pipeline_enabled?? '/assets' : '/javascripts' %>/comfortable_mexican_sofa"/>
   
   <% if ComfortableMexicanSofa.asset_pipeline_enabled? %>
     


### PR DESCRIPTION
The path includes /public. Some wymeditor files don't get loaded.

fixed js-assets-base-path when not using the asset pipeline (removed public/)
