### PR TITLE
bugfix incompatible character encodings

### DIFF
--- a/lib/comfortable_mexican_sofa/tag.rb
+++ b/lib/comfortable_mexican_sofa/tag.rb
@@ -124,7 +124,7 @@ private
           end
         end
       else
-        text
+        text.force_encoding("utf-8")
       end
     end.join('')
   end


### PR DESCRIPTION
cms tables are empty.
My fixture files under the pages directory contain Non ASCII character.(ex 日本語 )

$ rails c

> Cms::Site.find_or_create_by_hostname('example.com', label: 'sample')
> ComfortableMexicanSofa::Fixtures.import_all 'example.com'

comfortable_mexican_sofa-1.4.7/lib/comfortable_mexican_sofa/tag.rb:117:in `join': incompatible character encodings: UTF-8 and ASCII-8BIT (Encoding::CompatibilityError)
