### PR TITLE
Fix for ordering pages within cms-admin

### DIFF
--- a/app/controllers/cms_admin/pages_controller.rb
+++ b/app/controllers/cms_admin/pages_controller.rb
@@ -62,7 +62,7 @@ class CmsAdmin::PagesController < CmsAdmin::BaseController
   end
 
   def reorder
-    (params[:page] || []).each_with_index do |id, index|
+    (params[:cms_page] || []).each_with_index do |id, index|
       if (cms_page = Cms::Page.find_by_id(id))
         cms_page.update_attribute(:position, index)
       end


### PR DESCRIPTION
Hi 

It seems the params within the pages controller was wrong for the reorder action

i have changed it from page to cms_page.

There are a few other places params[:page] is used but i have not looked into what they do...

many thanks
