### PR TITLE
allow reorder on files layouts and snippets, extend cms_snippet_content

### DIFF
--- a/app/controllers/cms_admin/files_controller.rb
+++ b/app/controllers/cms_admin/files_controller.rb
@@ -71,6 +71,15 @@ class CmsAdmin::FilesController < CmsAdmin::BaseController
     end
   end
   
+  def reorder
+    (params[:cms_file] || []).each_with_index do |id, index|
+      if (cms_file = Cms::File.find_by_id(id))
+        cms_file.update_attribute(:position, index)
+      end
+    end
+    render :nothing => true
+  end
+  
 protected
   
   def load_file

--- a/app/controllers/cms_admin/layouts_controller.rb
+++ b/app/controllers/cms_admin/layouts_controller.rb
@@ -39,6 +39,15 @@ class CmsAdmin::LayoutsController < CmsAdmin::BaseController
     flash[:notice] = I18n.t('cms.layouts.deleted')
     redirect_to :action => :index
   end
+  
+  def reorder
+    (params[:cms_layout] || []).each_with_index do |id, index|
+      if (cms_layout = Cms::Layout.find_by_id(id))
+        cms_layout.update_attribute(:position, index)
+      end
+    end
+    render :nothing => true
+  end
 
 protected
 

--- a/app/controllers/cms_admin/snippets_controller.rb
+++ b/app/controllers/cms_admin/snippets_controller.rb
@@ -5,7 +5,7 @@ class CmsAdmin::SnippetsController < CmsAdmin::BaseController
 
   def index
     return redirect_to :action => :new if @site.snippets.count == 0
-    @snippets = @site.snippets.for_category(params[:category]).all(:order => 'label')
+    @snippets = @site.snippets.for_category(params[:category])
   end
 
   def new
@@ -38,6 +38,15 @@ class CmsAdmin::SnippetsController < CmsAdmin::BaseController
     @snippet.destroy
     flash[:notice] = I18n.t('cms.snippets.deleted')
     redirect_to :action => :index
+  end
+  
+  def reorder
+    (params[:cms_snippet] || []).each_with_index do |id, index|
+      if (cms_snippet = Cms::Snippet.find_by_id(id))
+        cms_snippet.update_attribute(:position, index)
+      end
+    end
+    render :nothing => true
   end
 
 protected

--- a/app/models/cms/file.rb
+++ b/app/models/cms/file.rb
@@ -18,14 +18,24 @@ class Cms::File < ActiveRecord::Base
   
   validates_uniqueness_of :file_file_name,
     :scope => :site_id
+    
+  # -- Scopes ---------------------------------------------------------------
+  default_scope order(:position)
   
   # -- Callbacks ------------------------------------------------------------
   before_save :assign_label
+  before_validation :assign_position,
+                    :on => :create
   
 protected
   
   def assign_label
     self.label = self.label.blank?? self.file_file_name.gsub(/\.[^\.]*?$/, '').titleize : self.label
+  end
+  
+  def assign_position
+    max = Cms::File.maximum(:position)
+    self.position = max ? max + 1 : 0
   end
   
 end

--- a/app/models/cms/layout.rb
+++ b/app/models/cms/layout.rb
@@ -14,6 +14,8 @@ class Cms::Layout < ActiveRecord::Base
   
   # -- Callbacks ------------------------------------------------------------
   before_validation :assign_label
+  before_validation :assign_position,
+                    :on => :create
   after_save    :clear_cached_page_content
   after_destroy :clear_cached_page_content
   
@@ -27,6 +29,9 @@ class Cms::Layout < ActiveRecord::Base
     :uniqueness => { :scope => :site_id },
     :format     => { :with => /^\w[a-z0-9_-]*$/i }
     
+  # -- Scopes ---------------------------------------------------------------
+  default_scope order(:position)
+  
   # -- Class Methods --------------------------------------------------------
   # Tree-like structure for layouts
   def self.options_for_select(site, layout = nil, current_layout = nil, depth = 0, spacer = '. . ')
@@ -70,6 +75,11 @@ protected
   
   def assign_label
     self.label = self.label.blank?? self.slug.try(:titleize) : self.label
+  end
+  
+  def assign_position
+    max = Cms::Layout.maximum(:position)
+    self.position = max ? max + 1 : 0
   end
   
   # Forcing page content reload

--- a/app/models/cms/snippet.rb
+++ b/app/models/cms/snippet.rb
@@ -13,8 +13,11 @@ class Cms::Snippet < ActiveRecord::Base
   
   # -- Callbacks ------------------------------------------------------------
   before_validation :assign_label
+  before_validation :assign_position,
+                    :on => :create
   after_save    :clear_cached_page_content
   after_destroy :clear_cached_page_content
+  
   
   # -- Validations ----------------------------------------------------------
   validates :site_id,
@@ -25,7 +28,9 @@ class Cms::Snippet < ActiveRecord::Base
     :presence   => true,
     :uniqueness => { :scope => :site_id },
     :format     => { :with => /^\w[a-z0-9_-]*$/i }
-  
+    
+  # -- Scopes ---------------------------------------------------------------
+  default_scope order(:position)
 protected
   
   def assign_label
@@ -37,6 +42,11 @@ protected
   # are hundreds of pages.
   def clear_cached_page_content
     site.pages.all.each{ |page| page.save }
+  end
+  
+  def assign_position
+    max = Cms::Snippet.maximum(:position)
+    self.position = max ? max + 1 : 0
   end
   
 end

--- a/app/views/cms_admin/files/index.html.erb
+++ b/app/views/cms_admin/files/index.html.erb
@@ -3,11 +3,15 @@
 
 <%= render :partial => 'cms_admin/categories/index', :object => 'Cms::File' %>
 
-<ul class='list'>
+<ul class='list sortable'>
   <% @files.each do |file| %>
     <li id='<%= dom_id(file) %>'>
       <div class='item'>
-        <div class='icon'></div>
+        <div class='icon'>
+          <% if !params[:category].present? %>
+            <div class='dragger'><span><%= t('cms.views.pages.drag') %></span></div>
+          <% end %>
+        </div>
         <div class='action_links'>
           <%= link_to t('.edit'), edit_cms_admin_site_file_path(@site, file) %>
           <%= link_to t('.delete'), cms_admin_site_file_path(@site, file), :method => :delete, :confirm => t('.are_you_sure') %>

--- a/app/views/cms_admin/layouts/_index_branch.html.erb
+++ b/app/views/cms_admin/layouts/_index_branch.html.erb
@@ -2,7 +2,11 @@
 
 <li id='cms_layout_<%= layout.id %>'>
   <div class='item'>
-    <div class='icon'></div>
+    <div class='icon'>
+      <% if !params[:category].present? %>
+        <div class='dragger'><span><%= t('cms.views.pages.drag') %></span></div>
+      <% end %>
+    </div>
     <div class='action_links'>
       <%= link_to t('.add_child_layout'), new_cms_admin_site_layout_path(@site, :parent_id => layout.id) %>
       <%= link_to t('.edit'), edit_cms_admin_site_layout_path(@site, layout) %>

--- a/app/views/cms_admin/layouts/index.html.erb
+++ b/app/views/cms_admin/layouts/index.html.erb
@@ -5,6 +5,6 @@
   <%= render :partial => 'cms_admin/sites/mirrors' %>
 <% end %>
 
-<ul class='list'>
+<ul class='list sortable'>
   <%= render :partial => 'index_branch', :collection => @layouts %>
 </ul>

--- a/app/views/cms_admin/snippets/index.html.erb
+++ b/app/views/cms_admin/snippets/index.html.erb
@@ -7,11 +7,15 @@
 
 <%= render :partial => 'cms_admin/categories/index', :object => 'Cms::Snippet' %>
 
-<ul class='list'>
+<ul class='list sortable'>
   <% @snippets.each do |snippet| %>
     <li id='cms_snippet_<%= snippet.id %>'>
       <div class='item'>
-        <div class='icon'></div>
+        <div class='icon'>
+          <% if !params[:category].present? %>
+            <div class='dragger'><span><%= t('cms.views.pages.drag') %></span></div>
+          <% end %>
+        </div>
         <div class='action_links'>
           <%= link_to t('.edit'), edit_cms_admin_site_snippet_path(@site, snippet) %>
           <%= link_to t('.delete'), cms_admin_site_snippet_path(@site, snippet), :method => :delete, :confirm => t('.are_you_sure') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,13 +15,23 @@ Rails.application.routes.draw do
           put :revert, :on => :member
         end
       end
-      resources :files
+      resources :files do
+        collection do
+          match :reorder
+        end
+      end
       resources :layouts do
+        collection do
+          match :reorder
+        end
         resources :revisions, :only => [:index, :show, :revert] do
           put :revert, :on => :member
         end
       end
       resources :snippets do
+        collection do
+          match :reorder
+        end
         resources :revisions, :only => [:index, :show, :revert] do
           put :revert, :on => :member
         end

--- a/db/migrate/upgrades/06_upgrade_to_1_5_0.rb
+++ b/db/migrate/upgrades/06_upgrade_to_1_5_0.rb
@@ -1,0 +1,11 @@
+class UpgradeTo150 < ActiveRecord::Migration
+  def self.up
+    add_column :cms_snippets, :position, :integer, :null => false, :default => 0
+    add_column :cms_files, :position, :integer, :null => false, :default => 0
+  end
+
+  def self.down
+    remove_column :cms_snippets, :position
+    remove_column :cms_files, :position
+  end
+end

--- a/lib/comfortable_mexican_sofa/view_methods.rb
+++ b/lib/comfortable_mexican_sofa/view_methods.rb
@@ -24,7 +24,12 @@ module ComfortableMexicanSofa::ViewMethods
   #   cms_snippet_content(:my_snippet)
   def cms_snippet_content(snippet_slug, cms_site = nil)
     return '' unless cms_site ||= (@cms_site || Cms::Site.find_site(request.host.downcase, request.fullpath))
-    return '' unless snippet = cms_site.snippets.find_by_slug(snippet_slug)
+    case snippet_slug
+    when Cms::Snippet
+      snippet = snippet_slug
+    else
+      return '' unless snippet = cms_site.snippets.find_by_slug(snippet_slug)
+    end
     render :inline => ComfortableMexicanSofa::Tag.process_content(Cms::Page.new, snippet.content)
   end
   

--- a/test/functional/cms_admin/files_controller_test.rb
+++ b/test/functional/cms_admin/files_controller_test.rb
@@ -165,4 +165,21 @@ class CmsAdmin::FilesControllerTest < ActionController::TestCase
     end
   end
   
+  def test_reorder
+    file_one = cms_files(:default)
+    file_two = cms_sites(:default).files.create(
+      :file => fixture_file_upload('files/valid_image.jpg')
+    )
+    assert_equal 0, file_one.position
+    assert_equal 1, file_two.position
+
+    post :reorder, :site_id => cms_sites(:default), :cms_file => [file_two.id, file_one.id]
+    assert_response :success
+    file_one.reload
+    file_two.reload
+
+    assert_equal 1, file_one.position
+    assert_equal 0, file_two.position
+  end
+  
 end

--- a/test/functional/cms_admin/layouts_controller_test.rb
+++ b/test/functional/cms_admin/layouts_controller_test.rb
@@ -100,5 +100,23 @@ class CmsAdmin::LayoutsControllerTest < ActionController::TestCase
       assert_equal 'Layout deleted', flash[:notice]
     end
   end
+  
+  def test_reorder
+    layout_one = cms_layouts(:default)
+    layout_two = cms_sites(:default).layouts.create!(
+      :label  => 'test',
+      :slug   => 'test'
+    )
+    assert_equal 0, layout_one.position
+    assert_equal 1, layout_two.position
+
+    post :reorder, :site_id => cms_sites(:default), :cms_layout => [layout_two.id, layout_one.id]
+    assert_response :success
+    layout_one.reload
+    layout_two.reload
+
+    assert_equal 1, layout_one.position
+    assert_equal 0, layout_two.position
+  end
 
 end

--- a/test/functional/cms_admin/snippets_controller_test.rb
+++ b/test/functional/cms_admin/snippets_controller_test.rb
@@ -117,5 +117,23 @@ class CmsAdmin::SnippetsControllerTest < ActionController::TestCase
       assert_equal 'Snippet deleted', flash[:notice]
     end
   end
+  
+  def test_reorder
+    snippet_one = cms_snippets(:default)
+    snippet_two = cms_sites(:default).snippets.create!(
+      :label  => 'test',
+      :slug   => 'test'
+    )
+    assert_equal 0, snippet_one.position
+    assert_equal 1, snippet_two.position
+
+    post :reorder, :site_id => cms_sites(:default), :cms_snippet => [snippet_two.id, snippet_one.id]
+    assert_response :success
+    snippet_one.reload
+    snippet_two.reload
+
+    assert_equal 1, snippet_one.position
+    assert_equal 0, snippet_two.position
+  end
 
 end

--- a/test/unit/view_methods_test.rb
+++ b/test/unit/view_methods_test.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../test_helper', File.dirname(__FILE__))
 
-class ViewMethodsTest < ActiveSupport::TestCase
+class ViewMethodsTest < ActionView::TestCase
+  include ComfortableMexicanSofa::ViewMethods
   
   class HelpersTestController < ActionController::Base
     helper { def hello; 'hello' end }


### PR DESCRIPTION
I've updated the files, layouts and snippets so that items can be reordered by dragging (as in pages), and extended the cms_snippet_content helper to accept snippet objects.
