### PR TITLE
Fix documentation for ComfortableMexicanSofa::HttpAuth

### DIFF
--- a/lib/comfortable_mexican_sofa/authentication/http_auth.rb
+++ b/lib/comfortable_mexican_sofa/authentication/http_auth.rb
@@ -1,8 +1,8 @@
 module ComfortableMexicanSofa::HttpAuth
   # Set username and password in config/initializers/comfortable_mexican_sofa.rb
   # Like this:
-  #   CmsHttpAuthentication.username = 'myname'
-  #   CmsHttpAuthentication.password = 'mypassword'
+  #   ComfortableMexicanSofa::HttpAuth.username = 'myname'
+  #   ComfortableMexicanSofa::HttpAuth.password = 'mypassword'
   mattr_accessor  :username,
                   :password
   
@@ -14,5 +14,4 @@ module ComfortableMexicanSofa::HttpAuth
       username == self.username && password == self.password
     end
   end
-  
 end


### PR DESCRIPTION
`CmsHttpAuthentication` is not referenced anywhere else in the app, so updates the documentation to match what is actually in the initializer.
