### PR TITLE
Don't clear cache on reorder actions

### DIFF
--- a/app/controllers/cms_admin/layouts_controller.rb
+++ b/app/controllers/cms_admin/layouts_controller.rb
@@ -44,9 +44,7 @@ class CmsAdmin::LayoutsController < CmsAdmin::BaseController
   
   def reorder
     (params[:cms_layout] || []).each_with_index do |id, index|
-      if (cms_layout = Cms::Layout.find_by_id(id))
-        cms_layout.update_attribute(:position, index)
-      end
+      Cms::Layout.where(:id => id).update_all(:position => index)
     end
     render :nothing => true
   end

--- a/app/controllers/cms_admin/pages_controller.rb
+++ b/app/controllers/cms_admin/pages_controller.rb
@@ -65,9 +65,7 @@ class CmsAdmin::PagesController < CmsAdmin::BaseController
 
   def reorder
     (params[:cms_page] || []).each_with_index do |id, index|
-      if (cms_page = Cms::Page.find_by_id(id))
-        cms_page.update_attribute(:position, index)
-      end
+      Cms::Page.where(:id => id).update_all(:position => index)
     end
     render :nothing => true
   end

--- a/app/controllers/cms_admin/snippets_controller.rb
+++ b/app/controllers/cms_admin/snippets_controller.rb
@@ -44,9 +44,7 @@ class CmsAdmin::SnippetsController < CmsAdmin::BaseController
   
   def reorder
     (params[:cms_snippet] || []).each_with_index do |id, index|
-      if (cms_snippet = Cms::Snippet.find_by_id(id))
-        cms_snippet.update_attribute(:position, index)
-      end
+      Cms::Snippet.where(:id => id).update_all(:position => index)
     end
     render :nothing => true
   end


### PR DESCRIPTION
On the snippets reorder action, for each snippet, callbacks are run, clearing the cache for each page (num snippets \* num pages database updates). For a reasonably sized site this will take minutes.

This commit addresses this by never instantiating database objects when reordering.

```
 Cms::Snippet.where(:id => id).update_all(:position => index)
```

also makes the same change for pages and layouts.
