### PR TITLE
Csv parameter parsing 

### DIFF
--- a/lib/comfortable_mexican_sofa/tag.rb
+++ b/lib/comfortable_mexican_sofa/tag.rb
@@ -1,5 +1,8 @@
 # encoding: utf-8
 
+# used for parsing tags
+require 'csv'
+
 # This module provides all Tag classes with neccessary methods.
 # Example class that will behave as a Tag:
 #   class MySpecialTag
@@ -32,7 +35,7 @@ module ComfortableMexicanSofa::Tag
         tag = self.new
         tag.page        = page
         tag.identifier  = match[1]
-        tag.params      = match[2].to_s.split(':')
+        tag.params      = match[2].to_s.parse_csv(:col_sep => ':') || []
         tag
       end
     end

--- a/test/unit/tags/helper_test.rb
+++ b/test/unit/tags/helper_test.rb
@@ -20,6 +20,15 @@ class HelperTagTest < ActiveSupport::TestCase
     assert_equal 'method_name', tag.identifier
     assert_equal ['param1', 'param2'], tag.params
   end
+
+  def test_initialize_tag_with_complex_parameters
+    assert tag = ComfortableMexicanSofa::Tag::Helper.initialize_tag(
+      cms_pages(:default), '{{ cms:helper:method_name:param1:"param:2" }}'
+    )
+    assert_equal 'method_name', tag.identifier
+    assert_equal ['param1', 'param:2'], tag.params
+
+  end
   
   def test_initialize_tag_failure
     [


### PR DESCRIPTION
Hey,

I've changed the tag parsing to use the csv parse_csv function, allowing more complex parameters to be used.

One case would be allowing an http:// link to be passed to a partial without breaking on the colon.

{{ cms:helper:print_link:"https://github.com" }} would now be valid when it wouldn't otherwise have been possible.

Also threw in a test case exposing the simplest version of the problem.

Cheers
~Clarke
