### PR TITLE
config.content_skip_filters

### DIFF
--- a/app/controllers/cms_content_controller.rb
+++ b/app/controllers/cms_content_controller.rb
@@ -9,6 +9,7 @@ class CmsContentController < ApplicationController
     :only => :render_html
   before_filter :load_cms_layout,
     :only => [:render_css, :render_js]
+  ComfortableMexicanSofa.config.content_skip_filters.each {|f| skip_filter f}
   
   def render_html(status = 200)
     if @cms_layout = @cms_page.layout

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -70,7 +70,10 @@ ComfortableMexicanSofa.configure do |config|
   # add a database_config. For example, setting it to 'cms' will look for a cms_#{Rails.env}
   # definition in your database.yml file
   #   config.database_config = nil
-  
+
+  # If you need to skip any before, after, around filters inherited
+  # from your main app on your content pages
+  #   config.content_skip_filters = []
 end
 
 # Default credentials for ComfortableMexicanSofa::HttpAuth

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -48,7 +48,12 @@ class ComfortableMexicanSofa::Configuration
   # Setting this to `cms` will look for a cms_#{Rails.env} database definition
   # in your database.yml file
   attr_accessor :database_config
-  
+
+  # Skip filters. If you have before or after filters in your
+  # application controller that you don't want to run for cms
+  # content pages
+  attr_accessor :content_skip_filters
+
   # Configuration defaults
   def initialize
     @cms_title            = 'ComfortableMexicanSofa CMS Engine'
@@ -70,6 +75,7 @@ class ComfortableMexicanSofa::Configuration
     }
     @admin_locale         = nil
     @database_config      = nil
+    @content_skip_filters  = []
   end
   
 end


### PR DESCRIPTION
If you need to skip any before, after, around filters inherited from your main app on your content pages.
