### PR TITLE
Sitemaps

### DIFF
--- a/app/controllers/cms_content_controller.rb
+++ b/app/controllers/cms_content_controller.rb
@@ -19,6 +19,9 @@ class CmsContentController < ApplicationController
     end
   end
 
+  def render_sitemap
+  end
+
   def render_css
     render :text => @cms_layout.css, :content_type => 'text/css'
   end

--- a/app/views/cms_content/render_sitemap.xml.builder
+++ b/app/views/cms_content/render_sitemap.xml.builder
@@ -1,0 +1,14 @@
+xml.instruct! :xml, :version => '1.0', :encoding => 'UTF-8'
+
+xml.urlset :xmlns => 'http://www.sitemaps.org/schemas/sitemap/0.9' do
+  @cms_site.pages.published.each do |page|
+    xml.url do 
+      xml.loc "http://#{@cms_site.hostname}#{"/" + @cms_site.path unless @cms_site.path.blank? }#{page.full_path}"
+      # just take some guesses the closer to the root means higher priority
+      # start subtracting 0.1 for every additional child page, max out at 0.1
+      # "/" splits to 0, "/child_page" splits to 2, hence weird max -1 
+      xml.priority [1 - (0.1 * ( ( [page.full_path.split("/").count, 1].max - 1 ) ) ), 0.1].max
+      xml.lastmod page.updated_at.strftime('%Y-%m-%d')
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
   scope :controller => :cms_content do
     get 'cms-css/:site_id/:identifier' => :render_css,  :as => 'cms_css'
     get 'cms-js/:site_id/:identifier'  => :render_js,   :as => 'cms_js'
+    get '(:cms_path)/sitemap'  => :render_sitemap,   :as => 'cms_sitemap', :constraints => {:format => /xml/}, :format => :xml
     get '/' => :render_html,  :as => 'cms_html',  :path => "(*cms_path)"
   end
   

--- a/test/fixtures/cms/layouts.yml
+++ b/test/fixtures/cms/layouts.yml
@@ -37,3 +37,4 @@ child:
   css: child_css
   js: child_js
   position: 0
+

--- a/test/fixtures/cms/sites.yml
+++ b/test/fixtures/cms/sites.yml
@@ -4,3 +4,10 @@ default:
   hostname: test.host
   path:
   is_mirrored: false
+
+site_with_path:
+  label: Site With Path
+  identifier: site-with-path
+  hostname: test.path.host
+  path: standard-path
+  is_mirrored: false

--- a/test/functional/cms_content_controller_test.rb
+++ b/test/functional/cms_content_controller_test.rb
@@ -155,5 +155,19 @@ class CmsContentControllerTest < ActionController::TestCase
     get :render_js, :site_id => cms_sites(:default).id, :identifier => 'bogus'
     assert_response 404
   end
-  
+
+  def test_render_sitemap
+    get :render_sitemap, :format => :xml
+    assert_response :success
+    assert_match '<loc>http://test.host/child-page</loc>', response.body
+  end
+
+  def test_render_sitemap_with_path
+    @request.host = 'test.path.host'
+    get :render_sitemap, :cms_path => cms_sites(:site_with_path).path, :format => :xml
+    assert_response :success
+    assert_equal cms_sites(:site_with_path), assigns(:cms_site)
+    assert !response.body.include?("<loc>"), "No pages, no loc's in the sitemap"
+  end
+
 end


### PR DESCRIPTION
This is a pretty simple sitemap generator. I elected to put the functionality inside of the cms_content controller rather than creating a cms_sitemap controller.

You can kill the logic around priorities if you want, its not actually required to be a valid sitemap. 

A bit of the fancyness in the routes and whatnot is to make sure it works properly with sites with :paths and if multiple sites and paths are all on the same host. 
