### PR TITLE
Logging with Rails.logger by default, also includes setters to change it, fixtures puts replaced with logger

### DIFF
--- a/lib/comfortable_mexican_sofa.rb
+++ b/lib/comfortable_mexican_sofa.rb
@@ -56,6 +56,14 @@ module ComfortableMexicanSofa
         klass.establish_connection "#{ComfortableMexicanSofa.config.database_config}_#{Rails.env}"
       end
     end
+
+    def logger=(new_logger)
+      @logger = new_logger
+    end
+
+    def logger
+      @logger ||= Rails.logger
+    end
     
   end
 end

--- a/lib/comfortable_mexican_sofa/fixtures.rb
+++ b/lib/comfortable_mexican_sofa/fixtures.rb
@@ -15,7 +15,7 @@ module ComfortableMexicanSofa::Fixtures
   def self.import_layouts(to_hostname, from_hostname = nil, path = nil, root = true, parent = nil, layout_ids = [])
     site = Cms::Site.find_or_create_by_hostname(to_hostname)
     unless path ||= find_fixtures_path((from_hostname || to_hostname), 'layouts')
-      $stdout.puts 'Cannot find Layout fixtures'
+      ComfortableMexicanSofa.logger.warn('Cannot find Layout fixtures')
       return
     end
     
@@ -56,9 +56,9 @@ module ComfortableMexicanSofa::Fixtures
       layout.parent = parent
       if layout.changed?
         if layout.save
-          $stdout.puts "[Fixtures] Saved Layout {#{layout.identifier}}"
+          ComfortableMexicanSofa.logger.warn("[Fixtures] Saved Layout {#{layout.identifier}}")
         else
-          $stdout.puts "[Fixtures] Failed to save Layout {#{layout.errors.inspect}}"
+          ComfortableMexicanSofa.logger.error("[Fixtures] Failed to save Layout {#{layout.errors.inspect}}")
           return
         end
       end
@@ -71,7 +71,7 @@ module ComfortableMexicanSofa::Fixtures
     # removing all db entries that are not in fixtures
     if root
       site.layouts.where('id NOT IN (?)', layout_ids.uniq).each{ |l| l.destroy } 
-      $stdout.puts 'Imported Layouts!'
+      ComfortableMexicanSofa.logger.warn('Imported Layouts!')
     end
     
     # returning ids of layouts in fixtures
@@ -81,7 +81,7 @@ module ComfortableMexicanSofa::Fixtures
   def self.import_pages(to_hostname, from_hostname = nil, path = nil, root = true, parent = nil, page_ids = [])
     site = Cms::Site.find_or_create_by_hostname(to_hostname)
     unless path ||= find_fixtures_path((from_hostname || to_hostname), 'pages')
-      $stdout.puts 'Cannot find Page fixtures'
+      ComfortableMexicanSofa.logger.warn('Cannot find Page fixtures')
       return
     end
     
@@ -123,9 +123,9 @@ module ComfortableMexicanSofa::Fixtures
       page.blocks_attributes = blocks_attributes if blocks_attributes.present?
       if page.changed? || blocks_attributes.present?
         if page.save
-          $stdout.puts "[Fixtures] Saved Page {#{page.full_path}}"
+          ComfortableMexicanSofa.logger.warn("[Fixtures] Saved Page {#{page.full_path}}")
         else
-          $stdout.puts "[Fixtures] Failed to save Page {#{page.errors.inspect}}"
+          ComfortableMexicanSofa.logger.warn("[Fixtures] Failed to save Page {#{page.errors.inspect}}")
           return
         end
       end
@@ -138,7 +138,7 @@ module ComfortableMexicanSofa::Fixtures
     # removing all db entries that are not in fixtures
     if root
       site.pages.where('id NOT IN (?)', page_ids.uniq).each{ |p| p.destroy }
-      $stdout.puts 'Imported Pages!'
+      ComfortableMexicanSofa.logger.warn('Imported Pages!')
     end
     
     # returning ids of layouts in fixtures
@@ -148,7 +148,7 @@ module ComfortableMexicanSofa::Fixtures
   def self.import_snippets(to_hostname, from_hostname = nil)
     site = Cms::Site.find_or_create_by_hostname(to_hostname)
     unless path = find_fixtures_path((from_hostname || to_hostname), 'snippets')
-      $stdout.puts 'Cannot find Snippet fixtures'
+      ComfortableMexicanSofa.logger.warn('Cannot find Snippet fixtures')
       return
     end
     
@@ -177,9 +177,9 @@ module ComfortableMexicanSofa::Fixtures
       # saving
       if snippet.changed?
         if snippet.save
-          $stdout.puts "[Fixtures] Saved Snippet {#{snippet.identifier}}"
+          ComfortableMexicanSofa.logger.warn("[Fixtures] Saved Snippet {#{snippet.identifier}}")
         else
-          $stdout.puts "[Fixtures] Failed to save Snippet {#{snippet.errors.inspect}}"
+          ComfortableMexicanSofa.logger.warn("[Fixtures] Failed to save Snippet {#{snippet.errors.inspect}}")
           return
         end
       end
@@ -188,7 +188,7 @@ module ComfortableMexicanSofa::Fixtures
     
     # removing all db entries that are not in fixtures
     site.snippets.where('id NOT IN (?)', snippet_ids).each{ |s| s.destroy }
-    $stdout.puts 'Imported Snippets!'
+    ComfortableMexicanSofa.logger.warn('Imported Snippets!')
   end
   
   def self.export_layouts(from_hostname, to_hostname = nil)

--- a/lib/tasks/comfortable_mexican_sofa.rake
+++ b/lib/tasks/comfortable_mexican_sofa.rake
@@ -7,12 +7,20 @@ namespace :comfortable_mexican_sofa do
   namespace :fixtures do
     
     desc 'Import Fixture data into database (options: FROM=example.local TO=example.com)'
+
     task :import => :environment do
       to    = ENV['TO'] || ENV['FROM']
       from  = ENV['FROM']
       
       puts "Importing CMS Fixtures from Folder [#{from}] to Site [#{to}] ..."
+
+      # changing so that logger is going straight to screen
+      logger_org = ComfortableMexicanSofa.logger
+      ComfortableMexicanSofa.logger = Logger.new(STDOUT)
+
       ComfortableMexicanSofa::Fixtures.import_all(to, from)
+
+      ComfortableMexicanSofa.logger = logger_org
     end
     
     desc 'Export database data into Fixtures (options: FROM=example.com TO=example.local)'
@@ -21,7 +29,15 @@ namespace :comfortable_mexican_sofa do
       from  = ENV['FROM']
       
       puts "Exporting CMS data from Site [#{from}] to Folder [#{to}] ..."
+
+      # changing so that logger is going straight to screen
+      logger_org = ComfortableMexicanSofa.logger
+      ComfortableMexicanSofa.logger = Logger.new(STDOUT)
+
       ComfortableMexicanSofa::Fixtures.export_all(from, to)
+
+      ComfortableMexicanSofa.logger = logger_org
+      
       puts 'Done!'
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,13 +8,6 @@ require 'rails/test_help'
 Paperclip::Attachment.default_options[:use_timestamp] = false
 
 class ActiveSupport::TestCase
-  
-  # Disabling the noise
-  $stdout_orig = $stdout
-  $stderr_orig = $stderr
-  $stdout = StringIO.new
-  $stderr = StringIO.new
-  
   fixtures :all
   include ActionDispatch::TestProcess
   


### PR DESCRIPTION
This small fix doesn't brake anything existing code.
## Fixture.rb annoying output

Fixture.rb used $stdout.puts to output information. It was annoying when I had a custom rake task to export or include all sites. I replaced it with ComfortableMexicanSofa.logger.warn.

Rake task includes now settings that logging is shown in screen in the same way as previously

```
ComfortableMexicanSofa.logger = Logger.new(STDOUT)
```
## New logger procedure

ComfortableMexicanSofa.logger= 
ComfortableMexicanSofa.logger (which returns Rails.logger by default)

This logger can be used from now on to log warnings etc. User can easily set the loggers warning level to whatever he chooses.
## Other implications

test_helper.rb had the following to disable the noise from fixture.rb

```
$stdout_orig = $stdout      
$stderr_orig = $stderr
$stdout = StringIO.new
$stderr = StringIO.new
```

Which also affected tests so that deprecation warnings were not shown. I hope this was unintentional? I got the following right away. These have to be fixed later.

```
DEPRECATION WARNING: Passing a template handler in the template name is deprecated. You can simply remove the handler name or pass render :handlers => [:erb] instead. (called from realtime at ....rvm/rubies/ree-1.8.7-2011.03/lib/ruby/1.8/benchmark.rb:308)
```
