### PR TITLE
fixed setting locale in admin pages

### DIFF
--- a/app/controllers/cms_admin/base_controller.rb
+++ b/app/controllers/cms_admin/base_controller.rb
@@ -7,6 +7,7 @@ class CmsAdmin::BaseController < ApplicationController
 
   before_filter :authenticate,
                 :load_admin_site,
+                :set_locale,
                 :load_fixtures,
                 :except => :jump
   
@@ -27,7 +28,11 @@ protected
       flash[:error] = I18n.t('cms.base.site_not_found')
       return redirect_to(new_cms_admin_site_path)
     end
-    I18n.locale = ComfortableMexicanSofa.config.admin_locale || @site.locale
+  end
+
+  def set_locale
+    I18n.locale = ComfortableMexicanSofa.config.admin_locale || (@site && @site.locale)
+    true
   end
 
   def load_fixtures

--- a/test/integration/sites_test.rb
+++ b/test/integration/sites_test.rb
@@ -83,10 +83,20 @@ class SitesTest < ActionDispatch::IntegrationTest
   
   def test_get_admin_with_forced_locale
     ComfortableMexicanSofa.config.admin_locale = :en
+    
     cms_sites(:default).update_attribute(:locale, 'fr')
     http_auth :get, cms_admin_site_pages_path(cms_sites(:default))
     assert_response :success
     assert_equal :en, I18n.locale
+
+    I18n.default_locale = :fr
+    I18n.locale = :fr
+    http_auth :get, cms_admin_sites_path()
+    assert_response :success
+    assert_equal :en, I18n.locale
+
+    I18n.default_locale = :en
+
   end
   
 end


### PR DESCRIPTION
Small bug fix. Previously if you set in your app

```
I18n.default_locale = :fi
ComfortableMexicanSofa.config.admin_locale = :en
```

and loaded "/cms-admin/sites/" the locale wasn't set to :en because SitesController has some skip_before_filter commands. Fixed with new before_filter.
