### PR TITLE
layout position handling

### DIFF
--- a/app/models/cms/layout.rb
+++ b/app/models/cms/layout.rb
@@ -77,6 +77,7 @@ protected
   end
   
   def assign_position
+    return if self.position.to_i > 0
     max = self.site.layouts.where(:parent_id => self.parent_id).maximum(:position)
     self.position = max ? max + 1 : 0
   end


### PR DESCRIPTION
Layout-model was always overwriting position attribute, small fix for that.

Btw. there is small bug in fixtures now. If fixtures file has "position: 0" it will be ignored and set as max+1. Only positions > 0 are used. I guess right fix for this would be to change database to accept nil values so you could recognize if position is set or not. I didn't figure out easier approach and I wasn't sure if we want to go through migration for such a small bug.
