### PR TITLE
Added config option for sweepers in admin base controller

### DIFF
--- a/app/controllers/cms_admin/base_controller.rb
+++ b/app/controllers/cms_admin/base_controller.rb
@@ -12,6 +12,8 @@ class CmsAdmin::BaseController < ApplicationController
                 :except => :jump
   
   layout 'cms_admin'
+
+  cache_sweeper ComfortableMexicanSofa.config.admin_sweeper.to_s.constantize if ComfortableMexicanSofa.config.admin_sweeper
   
   def jump
     path = ComfortableMexicanSofa.config.admin_route_redirect

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -7,6 +7,9 @@ class ComfortableMexicanSofa::Configuration
   
   # Module that will handle authentication to access cms-admin area
   attr_accessor :admin_auth
+
+  # A class that is included as a sweeper to admin base controller if it's set
+  attr_accessor :admin_sweeper
   
   # Module that will handle authentication for public pages
   attr_accessor :public_auth
@@ -53,6 +56,7 @@ class ComfortableMexicanSofa::Configuration
   def initialize
     @cms_title            = 'ComfortableMexicanSofa CMS Engine'
     @admin_auth           = 'ComfortableMexicanSofa::HttpAuth'
+    @admin_sweeper        = false
     @public_auth          = 'ComfortableMexicanSofa::DummyAuth'
     @seed_data_path       = nil
     @admin_route_prefix   = 'cms-admin'


### PR DESCRIPTION
I'm using sweepers to reset some external caches and send emails to our development flow when someone updates pages in cms.

This patch just enables easy way on including sweeper.

I could put the following example to wiki etc.

```
ComfortableMexicanSofa.configure do |config|
  config.admin_sweeper = CmsAdminSweeper
end

class CmsAdminSweeper < ActionController::Caching::Sweeper
  observe Cms::Page, Cms::Layout, Cms::Snippet

  def after_create(model)
    ...
  end

  # example of sending email after someone updates cms
  def after_update(model)
    return false if session.blank? || assigns(:site).blank?
    @site = assigns(:site)
    OtherEmails.message_to_admins("#{@site.hostname} (#{@site.locale}) cms update. Model #{model.inspect}").deliver
  end

  def after_destroy(model)
   ...
  end
end
```
