### PR TITLE
injection test added

### DIFF
--- a/test/unit/tags/helper_test.rb
+++ b/test/unit/tags/helper_test.rb
@@ -82,5 +82,13 @@ class HelperTagTest < ActiveSupport::TestCase
     assert_equal "<%= invalid('Rails.env') %>", tag.content
     assert_equal nil, tag.render
   end
+
+  def test_escaping_of_parameters
+ 	  tag = ComfortableMexicanSofa::Tag::Helper.initialize_tag(
+ 	    cms_pages(:default), '{{cms:helper:h:"\'+User.first.inspect+\'"}}'
+    )
+ 	  assert_equal %{<%= h('\\'+User.first.inspect+\\'') %>}, tag.content
+ 	  assert_equal %{<%= h('\\'+User.first.inspect+\\'') %>}, tag.render
+  end
   
 end


### PR DESCRIPTION
Extrated test from original pull request #141.

Only test. Implementation was in the original request. Close this if I have gotten this wrong, but:

When I run this test i get

```
  1) Failure:
test_escaping_of_parameters(HelperTagTest) [test/unit/tags/helper_test.rb:90]:
<"<%= h('\\'+User.first.inspect+\\'') %>"> expected but was
<"<%= h(''+User.first.inspect+'') %>">.
```

Which in my mind means that if you can write to cms page following

```
{{cms:helper:h:"\'+User.first.inspect +\'"}}
```

Notice the `"\'`-part where user adding extra escaping. The stuff in the middle is excecuted as such without any sanitization.
