### PR TITLE
scope category names on site too

### DIFF
--- a/app/models/cms/category.rb
+++ b/app/models/cms/category.rb
@@ -14,7 +14,7 @@ class Cms::Category < ActiveRecord::Base
     :presence   => true
   validates :label,
     :presence   => true,
-    :uniqueness => { :scope => :categorized_type }
+    :uniqueness => { :scope => [:categorized_type, :site_id] }
   validates :categorized_type,
     :presence   => true
     


### PR DESCRIPTION
Hi. I was using CMS (thanks btw!) and found that I had two mirrored sites, but I couldn't have the same category name on different sites.

I investigated and discovered that the Category name was not being scoped by the site_id. So I added that change and it now works for me. The tests all pass too. I hope this can be useful for you too. Thanks!
