### PR TITLE
Option for site_aliases

### DIFF
--- a/app/models/cms/site.rb
+++ b/app/models/cms/site.rb
@@ -37,7 +37,7 @@ class Cms::Site < ActiveRecord::Base
   def self.find_site(host, path = nil)
     return Cms::Site.first if Cms::Site.count == 1
     cms_site = nil
-    Cms::Site.find_all_by_hostname(host).each do |site|
+    Cms::Site.find_all_by_hostname(real_host_from_aliases(host)).each do |site|
       if site.path.blank?
         cms_site = site
       elsif "#{path}/".match /^\/#{Regexp.escape(site.path.to_s)}\//
@@ -47,7 +47,16 @@ class Cms::Site < ActiveRecord::Base
     end
     return cms_site
   end
-  
+
+  def self.real_host_from_aliases(host)
+    if ComfortableMexicanSofa.config.site_aliases
+      ComfortableMexicanSofa.config.site_aliases.each_with_index do |array, index|
+        return ComfortableMexicanSofa.config.site_aliases[index].first if array.include?(host)
+      end
+    end
+    host
+  end
+
 protected
 
   def assign_identifier

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -64,6 +64,12 @@ class ComfortableMexicanSofa::Configuration
   # Whitelist of partials paths that can be used via {{cms:partial}} tag. All partials
   # are accessible by default. Empty array will prevent rendering of all partials.
   attr_accessor :allowed_partials
+
+  # Site aliases, if you want to have aliases for your site, All find_site calls
+ 	# are converted to the first one on array. Good for harmozing production env with dev/testing envs.
+  # e.g. site_aliases = [['domain.com', 'domain.inv'], ['seconddomain.com', 'desconddomain.lvh.me']]
+  # Default is nil (not used)
+ 	attr_accessor :site_aliases
   
   # Configuration defaults
   def initialize
@@ -91,6 +97,7 @@ class ComfortableMexicanSofa::Configuration
     @allow_irb            = false
     @allowed_helpers      = nil
     @allowed_partials     = nil
+    @site_aliases         = nil
   end
   
 end

--- a/test/unit/models/site_test.rb
+++ b/test/unit/models/site_test.rb
@@ -119,6 +119,12 @@ class CmsSiteTest < ActiveSupport::TestCase
     
     assert_equal site_c,  Cms::Site.find_site('test2.host', '/fr')
     assert_equal site_c,  Cms::Site.find_site('test2.host', '/fr/some/path')
+
+    site_aliases_org = ComfortableMexicanSofa.config.site_aliases
+ 	  ComfortableMexicanSofa.config.site_aliases=[['test.host', 'test99.host']]
+ 	  assert_equal site_a,     Cms::Site.find_site('test99.host', '/some/path')
+    ComfortableMexicanSofa.config.site_aliases = site_aliases_org
+
   end
   
 end


### PR DESCRIPTION
We have our site at `domain.com`, but in development and testing I'm using `localhost.inv`. Other developer uses something like `domain.lvh.me`.

This patch adds following config option.

```
config.site_aliases =  [['domain.com', 'localhost.inv', 'domain.lvh.me'], ['domain.fi', 'localhost.fi.inv']]
```

In db we have site marked as "domain.com" in all databases, both production and development/testing.

Other option would be to add fixtures to be loaded according to own domains but this approach feels much more nicer as everybody has the same database infos.
