### PR TITLE
fixed tests so that there is no more warnings.

### DIFF
--- a/test/functional/cms_content_controller_test.rb
+++ b/test/functional/cms_content_controller_test.rb
@@ -22,7 +22,7 @@ class CmsContentControllerTest < ActionController::TestCase
   end
   
   def test_render_page_with_app_layout
-    cms_layouts(:default).update_attribute(:app_layout, 'cms_admin.html.erb')
+    cms_layouts(:default).update_attribute(:app_layout, 'cms_admin')
     get :render_html, :cms_path => ''
     assert_response :success
     assert assigns(:cms_page)
@@ -30,7 +30,7 @@ class CmsContentControllerTest < ActionController::TestCase
   end
   
   def test_render_page_with_xhr
-    cms_layouts(:default).update_attribute(:app_layout, 'cms_admin.html.erb')
+    cms_layouts(:default).update_attribute(:app_layout, 'cms_admin')
     xhr :get, :render_html, :cms_path => ''
     assert_response :success
     assert assigns(:cms_page)


### PR DESCRIPTION
Before we got the following:

DEPRECATION WARNING: Passing a template handler in the template name is deprecated. You can simply remove the handler name or pass render :handlers => [:erb] instead. (called from realtime at .../ree-1.8.7-2011.03/lib/ruby/1.8/benchmark.rb:308)

Partly related to #159
