### PR TITLE
Forcing 'text/html' content_type with render_html method

### DIFF
--- a/app/controllers/cms_content_controller.rb
+++ b/app/controllers/cms_content_controller.rb
@@ -14,7 +14,7 @@ class CmsContentController < ApplicationController
   def render_html(status = 200)
     if @cms_layout = @cms_page.layout
       app_layout = (@cms_layout.app_layout.blank? || request.xhr?) ? false : @cms_layout.app_layout
-      render :inline => @cms_page.content, :layout => app_layout, :status => status, :content_type => :html
+      render :inline => @cms_page.content, :layout => app_layout, :status => status, :content_type => 'text/html'
     else
       render :text => I18n.t('cms.content.layout_not_found'), :status => 404
     end


### PR DESCRIPTION
cms_content_controller render_html doesn't return any content type in response headers.

This manifested itself after switching to rails 3.2. Normally you wont notice it but with Opera browsers it suggests
you to save the page instead of viewing the page (saving html-file instead of displaying it).

Following request-header was from firebug: `Content-Type    ; charset=utf-8`

With this patch it will always return 'text/html'
