### PR TITLE
Categories work for camelcased resources

### DIFF
--- a/app/views/cms_admin/categories/_form.html.erb
+++ b/app/views/cms_admin/categories/_form.html.erb
@@ -2,9 +2,9 @@
 <% if (categories = @site.categories.of_type(object.class.to_s)).present? %>
   <%= form.simple_field t('.label'), nil, :class => 'categories' do %>
     <% categories.each do |category| %>
-      <%= hidden_field_tag "#{object.class.to_s.demodulize.downcase}[category_ids][#{category.id}]", 0, :id => nil %>
+      <%= hidden_field_tag "#{object.class.to_s.demodulize.underscore.downcase}[category_ids][#{category.id}]", 0, :id => nil %>
       <label>
-        <%= check_box_tag "#{object.class.to_s.demodulize.downcase}[category_ids][#{category.id}]", 1, object.categories.member?(category), :id => nil %>
+        <%= check_box_tag "#{object.class.to_s.demodulize.underscore.downcase}[category_ids][#{category.id}]", 1, object.categories.member?(category), :id => nil %>
         <%= category.label %>
       </label>
     <% end %>


### PR DESCRIPTION
category form was leaving out the underscore for user generated
camelcased resources and categories weren't being saved
