### PR TITLE
Fix wrong link in initializer

### DIFF
--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -33,7 +33,7 @@ ComfortableMexicanSofa.configure do |config|
   # File uploads use Paperclip and can support filesystem or s3 uploads.  Override
   # the upload method and appropriate settings based on Paperclip.  For S3 see:
   # http://rdoc.info/gems/paperclip/2.3.8/Paperclip/Storage/S3, and for 
-  # filesystem see: http://rdoc.info/gems/paperclip/2.3.8/Paperclip/Storage/S3
+  # filesystem see: http://rdoc.info/gems/paperclip/2.3.8/Paperclip/Storage/Filesystem
   #   config.upload_file_options = {:url => '/system/:class/:id/:attachment/:style/:filename'}
   
   # Sofa allows you to setup entire site from files. Database is updated with each


### PR DESCRIPTION
Just noticed that a link points to the Paperclip S3 instructions while it should point to the Filesystem ones
