### PR TITLE
File caching by site.

### DIFF
--- a/app/controllers/cms_admin/files_controller.rb
+++ b/app/controllers/cms_admin/files_controller.rb
@@ -3,6 +3,8 @@ class CmsAdmin::FilesController < CmsAdmin::BaseController
   skip_before_filter :load_fixtures
   
   before_filter :load_file, :only => [:edit, :update, :destroy]
+
+  cache_sweeper :file_sweeper
   
   def index
     return redirect_to :action => :new if @site.files.count == 0

--- a/app/sweepers/file_sweeper.rb
+++ b/app/sweepers/file_sweeper.rb
@@ -1,0 +1,11 @@
+class FileSweeper < ActionController::Caching::Sweeper
+  observe Cms::File
+
+  def expire(file)
+    expire_fragment('all_uploaded_files_' + file.site.id.to_s)
+  end
+
+  alias_method :after_create, :expire
+  alias_method :after_update, :expire
+  alias_method :after_destroy, :expire
+end

--- a/app/views/cms_admin/files/_index.html.erb
+++ b/app/views/cms_admin/files/_index.html.erb
@@ -9,8 +9,10 @@
   <% end %>
   
   <div class='uploaded_files'>
-    <% files_scope.order(:label).each do |file| %>
-      <%= render :partial => 'cms_admin/files/file', :object => file %>
+    <% cache('all_uploaded_files_' + @site.id.to_s) do %>
+      <% files_scope.order(:label).each do |file| %>
+        <%= render :partial => 'cms_admin/files/file', :object => file %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,7 @@ module ComfortableMexicanSofa
 
     # Custom directories with classes and modules you want to be autoloadable.
     # config.autoload_paths += %W(#{config.root}/extras)
+    config.autoload_paths += %W(#{config.root}/app/sweepers)
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.


### PR DESCRIPTION
The list of files shown on the right side is now available to be cached
when needed.  This is a step to improve performance when there are many
large files stored in that menu.
