### PR TITLE
New Layout Creation

### DIFF
--- a/app/models/cms/layout.rb
+++ b/app/models/cms/layout.rb
@@ -13,7 +13,8 @@ class Cms::Layout < ActiveRecord::Base
                   :content,
                   :css,
                   :js,
-                  :parent, :parent_id
+                  :parent, :parent_id,
+                  :app_layout
   
   # -- Relationships --------------------------------------------------------
   belongs_to :site


### PR DESCRIPTION
A one-liner that adds :app_layout to the attr_accessible list in app/models/cms/layout.rb.

This fixes an issue preventing CMS from creating a new layout with Rails 3.2.3 with config.active_record.whitelist_attributes = true .
