### PR TITLE
Allow Unicode accent characters in slug name

### DIFF
--- a/app/models/cms/page.rb
+++ b/app/models/cms/page.rb
@@ -48,7 +48,7 @@ class Cms::Page < ActiveRecord::Base
     :presence   => true
   validates :slug,
     :presence   => true,
-    :format     => /^\p{Alnum}[\.\p{Alnum}_-]*$/i,
+    :format     => /^\p{Alnum}[\.\p{Alnum}\p{Mark}_-]*$/i,
     :uniqueness => { :scope => :parent_id },
     :unless     => lambda{ |p| p.site && (p.site.pages.count == 0 || p.site.pages.root == self) }
   validates :layout,

--- a/test/unit/models/page_test.rb
+++ b/test/unit/models/page_test.rb
@@ -56,7 +56,15 @@ class CmsPageTest < ActiveSupport::TestCase
     page.slug = 'acción'
     assert page.valid?
   end
-  
+
+  def test_validation_of_slug_allows_unicode_accent_characters
+    page = cms_pages(:child)
+    thai_character_ko_kai = "\u0e01"
+    thai_character_mai_tho = "\u0E49"
+    page.slug = thai_character_ko_kai + thai_character_mai_tho
+    assert page.valid?
+  end
+
   def test_label_assignment
     page = cms_sites(:default).pages.new(
       :slug   => 'test',


### PR DESCRIPTION
"\u0e01\u0E49" is an example of a valid Thai string which fails the current Page slug validation because the second character is a "mark" (accent) rather than an Alnum.
