### PR TITLE
site aliases in DB + default site config

### DIFF
--- a/app/controllers/cms_admin/site_aliases_controller.rb
+++ b/app/controllers/cms_admin/site_aliases_controller.rb
@@ -1,0 +1,53 @@
+class CmsAdmin::SiteAliasesController < CmsAdmin::BaseController
+
+  before_filter :build_site,  :only => [:new, :create]
+  before_filter :load_site,   :only => [:edit, :update, :destroy]
+
+  def new
+    render
+  end
+
+  def edit
+    render
+  end
+
+  def create
+    @site_alias.save!
+    flash[:notice] = I18n.t('cms.site_aliases.created')
+    redirect_to cms_admin_sites_path()
+  rescue ActiveRecord::RecordInvalid
+    logger.detailed_error($!)
+    flash.now[:error] = I18n.t('cms.site_aliases.creation_failure')
+    render :action => :new
+  end
+
+  def update
+    @site_alias.update_attributes!(params[:site_alias])
+    flash[:notice] = I18n.t('cms.site_aliases.updated')
+    redirect_to :action => :edit, :id => @site_alias
+  rescue ActiveRecord::RecordInvalid
+    logger.detailed_error($!)
+    flash.now[:error] = I18n.t('cms.site_aliases.update_failure')
+    render :action => :edit
+  end
+
+  def destroy
+    @site_alias.destroy
+    flash[:notice] = I18n.t('cms.site_aliases.deleted')
+    redirect_to cms_admin_sites_path()
+  end
+
+protected
+
+  def build_site
+    @site_alias = @site.site_aliases.new(params[:site_alias])
+  end
+
+  def load_site
+    @site_alias = @site.site_aliases.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    flash[:error] = I18n.t('cms.site_aliases.not_found')
+    redirect_to :action => :index
+  end
+
+end

--- a/app/controllers/cms_content_controller.rb
+++ b/app/controllers/cms_content_controller.rb
@@ -46,6 +46,10 @@ protected
       Cms::Site.find_site(request.host.downcase, request.fullpath)
     end
     
+    if @cms_site.nil? && !ComfortableMexicanSofa.config.default_site.nil?
+      @cms_site = Cms::Site.find_by_identifier(ComfortableMexicanSofa.config.default_site)
+    end
+    
     if @cms_site
       if params[:cms_path].present?
         params[:cms_path].gsub!(/^#{@cms_site.path}/, '')

--- a/app/models/cms/site_alias.rb
+++ b/app/models/cms/site_alias.rb
@@ -1,0 +1,26 @@
+class Cms::SiteAlias < ActiveRecord::Base
+
+  ComfortableMexicanSofa.establish_connection(self)
+
+  self.table_name = 'cms_site_aliases'
+
+	attr_accessible :hostname
+
+  # -- Relationships --------------------------------------------------------
+  belongs_to :site
+
+  # -- Callbacks ------------------------------------------------------------
+
+  # -- Validations ----------------------------------------------------------
+  validates :site_id,
+    :presence   => true
+  validates :hostname,
+    :presence   => true,
+    :uniqueness => { :scope => :site_id },
+    :format     => { :with => /^[\w\.\-]+$/ }
+
+  # -- Scopes ---------------------------------------------------------------
+
+  # -- Class Methods --------------------------------------------------------
+
+end

--- a/app/views/cms_admin/site_aliases/_form.html.erb
+++ b/app/views/cms_admin/site_aliases/_form.html.erb
@@ -1,0 +1,5 @@
+<%= form.text_field :hostname %>
+
+<%= form.simple_field nil, nil, :class => 'submit_element' do %>
+  <%= form.submit t(@site_alias.new_record?? '.create' : '.update'), :disable_builder => true %>
+<% end %>

--- a/app/views/cms_admin/site_aliases/edit.html.erb
+++ b/app/views/cms_admin/site_aliases/edit.html.erb
@@ -1,0 +1,5 @@
+<h1><%= t('.title') %></h1>
+
+<%= comfy_form_for @site_alias, :as => :site_alias, :url => {:action => :update} do |form| %>
+  <%= render :partial => 'form', :object => form %>
+<% end %>

--- a/app/views/cms_admin/site_aliases/new.html.erb
+++ b/app/views/cms_admin/site_aliases/new.html.erb
@@ -1,0 +1,5 @@
+<h1><%= t('.title') %></h1>
+
+<%= comfy_form_for @site_alias, :as => :site_alias, :url => {:action => :create} do |form| %>
+  <%= render :partial => 'form', :object => form %>
+<% end %>

--- a/app/views/cms_admin/sites/index.html.erb
+++ b/app/views/cms_admin/sites/index.html.erb
@@ -10,6 +10,7 @@
           <%= link_to t('.select'),  cms_admin_site_pages_path(site) %>
           <%= link_to t('.edit'), edit_cms_admin_site_path(site) %>
           <%= link_to t('.delete'), cms_admin_site_path(site), :method => :delete, :confirm => t('.are_you_sure') %>
+          <%= link_to t('.add_site_alias'), new_cms_admin_site_site_alias_path(site) %>
         </div>
         <div class='label'>
           <%= link_to site.label, cms_admin_site_pages_path(site) %>
@@ -18,6 +19,24 @@
           </div>
         </div>
       </div>
+      <% if site.site_aliases.count > 0  %>
+        <ul>
+          <% site.site_aliases.each do |site_alias|  %>
+            <li id='cms_site_<%= site.id %>'>
+              <div class='item'>
+                <div class='icon'></div>
+                <div class='action_links'>
+                  <%= link_to t('.edit'), edit_cms_admin_site_site_alias_path(site, site_alias) %>
+                  <%= link_to t('.delete'), cms_admin_site_site_alias_path(site, site_alias), :method => :delete, :confirm => t('.are_you_sure') %>
+                </div>
+                <div class='label'>
+                  <%= site_alias.hostname %>
+                </div>
+              </div>
+            </li>
+          <% end  %>
+        </ul>
+      <% end  %>
     </li>
   <% end %>
 </ul>

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -97,6 +97,11 @@ ComfortableMexicanSofa.configure do |config|
   # Default is nil (not used)
   #   config.hostname_aliases = nil
   
+  # Default site identifier. If you have multiple sites and want to use
+  # particular site as default (when none of the defined sites match hostname
+  # and or path), set this to its identifier
+  #   config.default_site = nil
+
 end
 
 # Default credentials for ComfortableMexicanSofa::HttpAuth

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,14 @@ en:
       deleted: Site deleted
       not_found: Site not found
       
+    site_aliases:
+      created: Site alias created
+      creation_failure: Failed to create site alias
+      updated: Site alias updated
+      update_failure: Failed to update site alias
+      deleted: Site alias deleted
+      not_found: Site alias not found
+      
     layouts:
       created: Layout created
       creation_failure: Failed to create layout
@@ -114,6 +122,7 @@ en:
         edit: Edit
         delete: Delete
         are_you_sure: Are you sure you want to delete this site?
+        add_site_alias : Add site alias
       new:
         title: New Site
       edit:
@@ -122,6 +131,15 @@ en:
         create: Create Site
         update: Update Site
         
+    site_aliases:
+      new:
+        title: New Site alias
+      edit:
+        title: Editing Site alias
+      form:
+        create: Create Site alias
+        update: Update Site alias
+
     layouts:
       index:
         title: Layouts

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :cms_admin, :path => ComfortableMexicanSofa.config.admin_route_prefix, :except => :show do
     get '/', :to => 'base#jump'
     resources :sites do
+      resources :site_aliases
       resources :pages do
         get  :form_blocks,    :on => :member
         get  :toggle_branch,  :on => :member

--- a/db/migrate/01_create_cms.rb
+++ b/db/migrate/01_create_cms.rb
@@ -21,6 +21,14 @@ class CreateCms < ActiveRecord::Migration
     add_index :cms_sites, :hostname
     add_index :cms_sites, :is_mirrored
     
+    # -- Site Aliasess ------------------------------------------------------
+    create_table :cms_site_aliases do |t|
+      t.integer :site_id,     :null => false
+      t.string :hostname,     :null => false
+    end
+    add_index :cms_site_aliases, :hostname
+    add_index :cms_site_aliases, :site_id
+
     # -- Layouts ------------------------------------------------------------
     create_table :cms_layouts do |t|
       t.integer :site_id,     :null => false
@@ -124,6 +132,7 @@ class CreateCms < ActiveRecord::Migration
   
   def self.down
     drop_table :cms_sites
+    drop_table :cms_site_aliases
     drop_table :cms_layouts
     drop_table :cms_pages
     drop_table :cms_snippets

--- a/db/upgrade_migrations/08_upgrade_to_1_7_0.rb
+++ b/db/upgrade_migrations/08_upgrade_to_1_7_0.rb
@@ -1,0 +1,15 @@
+class UpgradeTo170 < ActiveRecord::Migration
+  def self.up
+    # -- Sites --------------------------------------------------------------
+    create_table :cms_site_aliases do |t|
+      t.integer :site_id,     :null => false
+      t.string :hostname,     :null => false
+    end
+    add_index :cms_site_aliases, :hostname
+    add_index :cms_site_aliases, :site_id
+  end
+
+  def self.down
+    drop_table :cms_site_aliases
+  end
+end

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -75,6 +75,11 @@ class ComfortableMexicanSofa::Configuration
   # Default is nil (not used)
   attr_accessor :hostname_aliases
   
+  # Default site identifier. If you have multiple sites and want to use
+  # particular site as default (when none of the defined sites match hostname
+  # and or path), set this to its identifier
+	attr_accessor :default_site
+  
   # Configuration defaults
   def initialize
     @cms_title            = 'ComfortableMexicanSofa CMS Engine'
@@ -103,6 +108,7 @@ class ComfortableMexicanSofa::Configuration
     @allowed_helpers      = nil
     @allowed_partials     = nil
     @hostname_aliases     = nil
+    @default_site         = nil
   end
   
 end

--- a/test/fixtures/cms/site_aliases.yml
+++ b/test/fixtures/cms/site_aliases.yml
@@ -1,0 +1,3 @@
+default:
+  site: default
+  hostname: bogus.alias

--- a/test/functional/cms_admin/site_aliases_controller_test.rb
+++ b/test/functional/cms_admin/site_aliases_controller_test.rb
@@ -1,0 +1,84 @@
+require File.expand_path('../../test_helper', File.dirname(__FILE__))
+
+class CmsAdmin::SiteAliasesControllerTest < ActionController::TestCase
+
+  def test_get_new
+    site = cms_sites(:default)
+    get :new, :site_id => site
+    assert_response :success
+    assert assigns(:site_alias)
+    assert_template :new
+    assert_select "form[action=/cms-admin/sites/#{site.id}/site_aliases]"
+  end
+
+  def test_get_edit
+    site = cms_sites(:default)
+    site_alias = cms_site_aliases(:default)
+    get :edit, :site_id => cms_sites(:default), :id => site_alias
+    assert_response :success
+    assert assigns(:site)
+    assert_template :edit
+    assert_select "form[action=/cms-admin/sites/#{site.id}/site_aliases/#{site_alias.id}]"
+  end
+
+  def test_get_edit_failure
+    get :edit, :id => 'not_found'
+    assert_response :redirect
+    assert_redirected_to :action => :index
+    assert_equal 'Site alias not found', flash[:error]
+  end
+
+  def test_create
+    assert_difference 'Cms::SiteAlias.count' do
+      post :create, :site_id => cms_sites(:default), :site_alias => {
+        :hostname   => 'test.site.local'
+      }
+      assert_response :redirect
+      site = Cms::SiteAlias.last
+      assert_redirected_to cms_admin_sites_path()
+      assert_equal 'Site alias created', flash[:notice]
+    end
+  end
+
+  def test_creation_failure
+    assert_no_difference 'Cms::SiteAlias.count' do
+      post :create, :site_id => cms_sites(:default), :site_alias => { }
+      assert_response :success
+      assert_template :new
+      assert_equal 'Failed to create site alias', flash[:error]
+    end
+  end
+
+  def test_update
+    site_alias = cms_site_aliases(:default)
+    put :update, :site_id => site_alias.site, :id => site_alias, :site_alias => {
+      :hostname => 'new.site_alias.local'
+    }
+    assert_response :redirect
+    assert_redirected_to :action => :edit, :site_id => cms_sites(:default), :id => site_alias
+    assert_equal 'Site alias updated', flash[:notice]
+    site_alias.reload
+    assert_equal 'new.site_alias.local', site_alias.hostname
+  end
+
+  def test_update_failure
+    site_alias = cms_site_aliases(:default)
+    put :update, :site_id => site_alias.site, :id => site_alias, :site_alias => {
+      :hostname => ''
+    }
+    assert_response :success
+    assert_template :edit
+    site_alias.reload
+    assert_not_equal '', site_alias.hostname
+    assert_equal 'Failed to update site alias', flash[:error]
+  end
+
+  def test_destroy
+    assert_difference 'Cms::SiteAlias.count', -1 do
+      delete :destroy, :id => cms_site_aliases(:default)
+      assert_response :redirect
+      assert_redirected_to cms_admin_sites_path()
+      assert_equal 'Site alias deleted', flash[:notice]
+    end
+  end
+end

--- a/test/integration/sites_test.rb
+++ b/test/integration/sites_test.rb
@@ -26,6 +26,38 @@ class SitesTest < ActionDispatch::IntegrationTest
     assert_equal 'test.host', assigns(:cms_site).hostname
   end
   
+  def test_get_public_with_aliased_site
+    site_b = Cms::Site.create!(:identifier => 'site-b', :hostname => 'test.hostx', :path => '')
+
+    host! 'bogus.alias'
+    get '/'
+    assert_response :success
+    assert assigns(:cms_site)
+    assert_equal 'test.host', assigns(:cms_site).hostname
+
+    host! 'bogus.aliasx'
+	  assert_exception_raised ActionController::RoutingError, 'Site Not Found' do
+			get '/'
+		end
+  end
+
+  def test_get_public_with_default_site
+    site_b = Cms::Site.create!(:identifier => 'site-b', :hostname => 'test.hostx', :path => '')
+
+    ComfortableMexicanSofa.config.default_site = cms_sites(:default).identifier
+    host! 'bogus.aliasx'
+    get '/'
+    assert_response :success
+    assert assigns(:cms_site)
+    assert_equal 'test.host', assigns(:cms_site).hostname
+
+    ComfortableMexicanSofa.config.default_site = nil
+    host! 'bogus.aliasx'
+	  assert_exception_raised ActionController::RoutingError, 'Site Not Found' do
+			get '/'
+		end
+  end
+
   def test_get_public_page_with_sites_with_different_paths
     Cms::Site.delete_all
     site_a = Cms::Site.create!(:identifier => 'site-a', :hostname => 'test.host', :path => '')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,6 +42,7 @@ class ActiveSupport::TestCase
       config.allowed_helpers      = nil
       config.allowed_partials     = nil
       config.hostname_aliases     = nil
+			config.default_site         = nil			
     end
     ComfortableMexicanSofa::HttpAuth.username = 'username'
     ComfortableMexicanSofa::HttpAuth.password = 'password'

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -33,6 +33,7 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal nil, config.allowed_helpers
     assert_equal nil, config.allowed_partials
     assert_equal nil, config.hostname_aliases
+	  assert_equal nil, config.default_site	  
   end
   
   def test_initialization_overrides

--- a/test/unit/models/site_alias_test.rb
+++ b/test/unit/models/site_alias_test.rb
@@ -1,0 +1,24 @@
+require File.expand_path('../../test_helper', File.dirname(__FILE__))
+
+class CmsSiteAliasTest < ActiveSupport::TestCase
+
+  def test_fixtures_validity
+    Cms::SiteAlias.all.each do |site_alias|
+      assert site_alias.valid?, site_alias.errors.full_messages.to_s
+    end
+  end
+
+  def test_validation
+    site_alias = cms_sites(:default).site_aliases.new()
+    assert site_alias.invalid?
+    assert_has_errors_on site_alias, :hostname
+  end
+
+  def test_creation
+    assert_difference 'Cms::SiteAlias.count' do
+      cms_sites(:default).site_aliases.create!(
+        :hostname   => 'test.test'
+      )
+    end
+  end
+end

--- a/test/unit/models/site_test.rb
+++ b/test/unit/models/site_test.rb
@@ -79,12 +79,14 @@ class CmsSiteTest < ActiveSupport::TestCase
         assert_difference 'Cms::Page.count', -2 do
           assert_difference 'Cms::Snippet.count', -1 do
             assert_difference 'Cms::Category.count', -1 do
+              assert_difference 'Cms::SiteAlias.count', -1 do
               cms_sites(:default).destroy
             end
           end
         end
       end
     end
+  end
   end
   
   def test_scope_mirrored


### PR DESCRIPTION
In current branch, there is possibility to add aliases to sites in config file. For our purposes we needed to do this from web administration so i added all necessary stuff to get this working (including tests) - second feature in this commit is connected wit the first one - it is possibility to set default site (sort of fall back when no site matches) in config file.

Maybe you will be interested in these. 
