### PR TITLE
Validate length of Cms::Page slug and full_path

### DIFF
--- a/app/assets/stylesheets/comfortable_mexican_sofa/form.css
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/form.css
@@ -47,6 +47,17 @@
 #cms_body .form_element.check_box_element input {
   width: auto;
 }
+
+#cms_body .form_element .value input[disabled]{
+  background-color: #F1F1F1;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
 #cms_body .page_form_extras {
   margin-bottom: 10px;
 }

--- a/app/views/cms_admin/pages/_form.html.erb
+++ b/app/views/cms_admin/pages/_form.html.erb
@@ -14,6 +14,7 @@
 <div class='page_form_extras'>
   <% unless @site.pages.count == 0 || @site.pages.root == @page%>
     <%= form.text_field :slug, :id => 'slug' %>
+    <%= form.text_field :full_path, :id => 'full-path', :disabled => true %>
   <% end %>
   <% if (options = Cms::Layout.options_for_select(@site)).present? %>
     <%= form.select :layout_id, options, {}, 'data-url' => form_blocks_cms_admin_site_page_path(@site, @page.id.to_i) %>

--- a/test/integration/render_cms_test.rb
+++ b/test/integration/render_cms_test.rb
@@ -108,7 +108,7 @@ class RenderCmsTest < ActionDispatch::IntegrationTest
   # -- Page Render Test -----------------------------------------------------
   def test_implicit_cms_page
     page = cms_pages(:child)
-    page.update_attribute(:slug, 'render-basic')
+    page.update_attributes(slug: 'render-basic')
     get '/render-basic?type=page_implicit'
     assert_response :success
     assert assigns(:cms_site)
@@ -120,7 +120,7 @@ class RenderCmsTest < ActionDispatch::IntegrationTest
   
   def test_explicit_cms_page
     page = cms_pages(:child)
-    page.update_attribute(:slug, 'test-page')
+    page.update_attributes(slug: 'test-page')
     get '/render-page?type=page_explicit'
     assert_response :success
     assert assigns(:cms_site)
@@ -132,7 +132,7 @@ class RenderCmsTest < ActionDispatch::IntegrationTest
   
   def test_explicit_cms_page_with_status
     page = cms_pages(:child)
-    page.update_attribute(:slug, 'test-page')
+    page.update_attributes(slug: 'test-page')
     get '/render-page?type=page_explicit_with_status'
     assert_response 404
     assert assigns(:cms_site)
@@ -144,7 +144,7 @@ class RenderCmsTest < ActionDispatch::IntegrationTest
   
   def test_explicit_cms_page_failure
     page = cms_pages(:child)
-    page.update_attribute(:slug, 'invalid')
+    page.update_attributes(slug: 'invalid')
     assert_exception_raised ComfortableMexicanSofa::MissingPage do
       get '/render-page?type=page_explicit'
     end

--- a/test/unit/models/page_test.rb
+++ b/test/unit/models/page_test.rb
@@ -55,6 +55,24 @@ class CmsPageTest < ActiveSupport::TestCase
 
     page.slug = 'acción'
     assert page.valid?
+
+    page.slug = 'a'*256
+    assert page.invalid?
+    assert page.errors[:slug].present?
+
+    page.slug = 'a'*254
+    assert page.valid?
+  end
+
+
+  def test_validation_of_full_path
+    page = cms_pages(:child)
+    page.slug = 'a'*255
+    assert page.invalid?
+    assert page.errors[:full_path].present?
+
+    page.slug = 'a'*254
+    assert page.valid?
   end
 
   def test_validation_of_slug_allows_unicode_accent_characters


### PR DESCRIPTION
Currently databases are just chopping off the tail end of any slug or full_path that is longer than the field lengths. With this change a helpful error message will be displayed to the user.

We also added a view only field of full_path in the admin edit page, to show this error message.

We also added some handy styles for disabled inputs.
