### PR TITLE
Set sites only if not already defined.

### DIFF
--- a/app/controllers/cms_admin/sites_controller.rb
+++ b/app/controllers/cms_admin/sites_controller.rb
@@ -9,7 +9,7 @@ class CmsAdmin::SitesController < CmsAdmin::BaseController
   def index
     return redirect_to :action => :new if Cms::Site.count == 0
     @site = Cms::Site.find_by_id(session[:site_id])
-    @sites = Cms::Site.all
+    @sites ||= Cms::Site.all
   end
 
   def new


### PR DESCRIPTION
This change allows to define the listed sites in the module responsible for authentication 'admin_auth'.
So that only the sites of the defined customer can be selected.

With this change it would be possible to give different customers access to the same application, and make sure they can not interfere with other sites as their own.

The is also a filter defined for the site_id, but this can be handled without changing the gem code.
