### PR TITLE
Fixed el-rte toolbar display error

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/application.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/application.js
@@ -174,7 +174,7 @@ $.CMS = function(){
     },
 
     enable_page_form : function(){
-      if ($('#tag_namespaces>ul>li').size() > 1){
+      if ($('#tag_namespaces>ul>li').size() > 0){
         $('#tag_namespaces').tabs();
       }
       $('input[name=commit]').click(function() {


### PR DESCRIPTION
Set $.CMS.config.elRTE.cssfiles to make sure toolbar is displayed.
Remove js-call to make sure toolbar is not displayed wrong.
