### PR TITLE
Adding config variable so CMS can do uploads without needing to install ImageMagick

### DIFF
--- a/app/models/cms/file.rb
+++ b/app/models/cms/file.rb
@@ -22,7 +22,8 @@ class Cms::File < ActiveRecord::Base
   has_attached_file :file, ComfortableMexicanSofa.config.upload_file_options.merge(
     # dimensions accessor needs to be set before file assignment for this to work
     :styles => lambda { |f|
-      (f.instance.dimensions.blank?? { } : { :original => f.instance.dimensions }).merge(
+      (f.instance.dimensions.blank? || ComfortableMexicanSofa.config.skip_thumbnails ?
+       { } : { :original => f.instance.dimensions }).merge(
         :cms_thumb => '80x60#'
       )
     }
@@ -49,7 +50,7 @@ class Cms::File < ActiveRecord::Base
   
   # -- Instance Methods -----------------------------------------------------
   def is_image?
-    IMAGE_MIMETYPES.include?(file_content_type)
+    IMAGE_MIMETYPES.include?(file_content_type) and !ComfortableMexicanSofa.config.skip_thumbnails
   end
   
 protected

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -96,6 +96,10 @@ ComfortableMexicanSofa.configure do |config|
   # e.g. config.site_aliases = {'host.com' => 'host.inv', 'host_a.com' => ['host.lvh.me', 'host.dev']}
   # Default is nil (not used)
   #   config.hostname_aliases = nil
+
+  # Skips thumbnail generation and image validation for uploads of image files
+  # Setting this to true allows you to run CMS and Paperclip without installing ImageMagick
+  #   config.skip_thumbnails = true
   
 end
 

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -75,6 +75,10 @@ class ComfortableMexicanSofa::Configuration
   # Default is nil (not used)
   attr_accessor :hostname_aliases
 
+  # Skips thumbnail generation and image validation for uploads of image files
+  # Setting this to true allows you to run CMS with Paperclip without installing ImageMagick
+  attr_accessor :skip_thumbnails
+
   # Configuration defaults
   def initialize
     @cms_title            = 'ComfortableMexicanSofa CMS Engine'
@@ -106,6 +110,7 @@ class ComfortableMexicanSofa::Configuration
     @allowed_helpers      = nil
     @allowed_partials     = nil
     @hostname_aliases     = nil
+    @skip_thumbnails      = false
   end
 
 end


### PR DESCRIPTION
Added a config variable (skip_thumbnails) which makes CMS bypass the thumbnail processor and the Identify call in Paperclip that require ImageMagick to be installed. This allows Comfortable Mexican Sofa to run with full file uploads  and the least amount of dependencies (no ImageMagick), especially if image manipulation is not the point of the developer using CMS.
