### PR TITLE
Added support for rendering CMS Layout with options (IE. action: 'new')

### DIFF
--- a/lib/comfortable_mexican_sofa/render_methods.rb
+++ b/lib/comfortable_mexican_sofa/render_methods.rb
@@ -59,7 +59,7 @@ module ComfortableMexicanSofa::RenderMethods
         if @cms_layout = @cms_site && @cms_site.layouts.find_by_identifier(identifier)
           cms_app_layout = @cms_layout.try(:app_layout)
           cms_page = @cms_site.pages.build(:layout => @cms_layout)
-          cms_blocks = options.delete(:cms_blocks) || { :content => render_to_string(:layout => false)}
+          cms_blocks = options.delete(:cms_blocks) || { :content => render_to_string({ :layout => false }.merge(options)) }
           cms_blocks.each do |identifier, value|
             content = if value.is_a?(Hash)
               render_to_string(value.keys.first.to_sym => value[value.keys.first], :layout => false)

--- a/test/fixtures/views/render_test/new.html.erb
+++ b/test/fixtures/views/render_test/new.html.erb
@@ -1,0 +1,1 @@
+Can render CMS layout and specify action

--- a/test/integration/render_cms_test.rb
+++ b/test/integration/render_cms_test.rb
@@ -80,9 +80,14 @@ class RenderCmsTest < ActionDispatch::IntegrationTest
         render :cms_layout => 'invalid'
       when 'layout_defaults_with_site'
         render :cms_layout => 'default', :cms_site => 'site-b'
+      when 'layout_with_action'
+        render :cms_layout => 'default', :action => :new
       else
         raise 'Invalid or no param[:type] provided'
       end
+    end
+
+    def new
     end
   end
   
@@ -189,6 +194,16 @@ class RenderCmsTest < ActionDispatch::IntegrationTest
     get '/render-layout?type=layout_with_status'
     assert_response 404
     assert_equal 'TestTemplate TestValue', response.body
+    assert assigns(:cms_site)
+    assert assigns(:cms_layout)
+    assert_equal cms_layouts(:default), assigns(:cms_layout)
+  end
+
+  def test_cms_layout_with_action
+    cms_layouts(:default).update_column(:content, '{{cms:page:content}} {{cms:page:content_b}} {{cms:page:content_c}}')
+    get '/render-layout?type=layout_with_action'
+    assert_response :success
+    assert_equal "Can render CMS layout and specify action\n  ", response.body
     assert assigns(:cms_site)
     assert assigns(:cms_layout)
     assert_equal cms_layouts(:default), assigns(:cms_layout)


### PR DESCRIPTION
- added test for specifically for 'action' option
- can now do the following within your Rails app controller: render({ cms_layout: 'three-column', action: :new })
