### PR TITLE
avoid many queries in pages#index

### DIFF
--- a/app/controllers/cms_admin/pages_controller.rb
+++ b/app/controllers/cms_admin/pages_controller.rb
@@ -8,6 +8,7 @@ class CmsAdmin::PagesController < CmsAdmin::BaseController
 
   def index
     return redirect_to :action => :new if @site.pages.count == 0
+    @pages_by_parent = @site.pages.includes(:categories).all.group_by(&:parent_id)
     if params[:category].present?
       @pages = @site.pages.includes(:categories).for_category(params[:category]).all(:order => 'label')
     else
@@ -55,6 +56,7 @@ class CmsAdmin::PagesController < CmsAdmin::BaseController
   end
 
   def toggle_branch
+    @pages_by_parent = @site.pages.includes(:categories).all.group_by(&:parent_id)
     @page = @site.pages.find(params[:id])
     s   = (session[:cms_page_tree] ||= [])
     id  = @page.id.to_s

--- a/app/views/cms_admin/pages/_index_branch.html.erb
+++ b/app/views/cms_admin/pages/_index_branch.html.erb
@@ -1,7 +1,9 @@
-<% 
-  page        ||= index_branch 
-  has_children  = page.children.present?
-  has_siblings  = page.siblings.present?
+<%
+  page        ||= index_branch
+  children      = @pages_by_parent[page.id]
+  siblings      = @pages_by_parent[page.parent_id]
+  has_children  = children.present?
+  has_siblings  = siblings.size > 1
   branch_open   = (session[:cms_page_tree] || []).member?(page.id.to_s) || page.root?
   category_view = params[:category].present?
 %>
@@ -9,7 +11,7 @@
 <li id='<%= dom_id(page) %>'>
   <div class='item'>
     <div class='toggle <%= 'open' if branch_open %>'>
-      <%= 
+      <%=
         if !category_view && has_children && !page.root?
           link_to span_tag(t('.toggle')), toggle_branch_cms_admin_site_page_path(@site, page), :remote => true
         end
@@ -35,7 +37,7 @@
   </div>
   <% if !category_view && has_children && branch_open %>
     <ul>
-      <%= render :partial => 'index_branch', :collection => page.children %>
+      <%= render :partial => 'index_branch', :collection => children %>
     </ul>
   <% end %>
 </li>

--- a/lib/comfortable_mexican_sofa/extensions/acts_as_tree.rb
+++ b/lib/comfortable_mexican_sofa/extensions/acts_as_tree.rb
@@ -80,7 +80,7 @@ module ComfortableMexicanSofa::ActsAsTree
     
     # Checks if this node is a root
     def root?
-      !self.parent
+      !self.parent_id
     end
     
     # Returns all siblings of the current node.


### PR DESCRIPTION
The current pages#index performs multiple queries for each page shown.

This commit Fetches all pages for a site in pages#index, and uses those to find parent and siblings. It also eager loads categories, which are rendered on each page.

This should eliminate all uncached queries.
