### PR TITLE
cms:file should not return true for is_cms_block?

### DIFF
--- a/lib/comfortable_mexican_sofa/tag.rb
+++ b/lib/comfortable_mexican_sofa/tag.rb
@@ -93,7 +93,7 @@ module ComfortableMexicanSofa::Tag
     
     # Checks if this tag is using Cms::Block
     def is_cms_block?
-      %w(page field collection file).member?(self.class.to_s.demodulize.underscore.split(/_/).first)
+      %w(page field collection).member?(self.class.to_s.demodulize.underscore.split(/_/).first)
     end
     
     # Used in displaying form elements for Cms::Block

--- a/test/unit/tag_test.rb
+++ b/test/unit/tag_test.rb
@@ -212,6 +212,11 @@ class TagTest < ActiveSupport::TestCase
       cms_pages(:default), '{{ cms:snippet:label }}'
     )
     assert !tag.is_cms_block?
+
+    tag = ComfortableMexicanSofa::Tag::File.initialize_tag(
+      cms_pages(:default), '{{ cms:file:sample.jpg }}'
+    )
+    assert !tag.is_cms_block?
   end
   
   def test_content_with_irb_disabled


### PR DESCRIPTION
cms:file tags were returning true for is_cms_block?, despite not using a block. I'm assuming this is an mistake, since PageFile and PageFiles are the file tags which use a block.

This was causing oddness with the new namespace support in pages: {{cms:file:test.png}} was interpreted as being from the 'test' namespace. Errors were missed due to the rescue nil when calling the form builder in /pages/_form_blocks.html.erb.
