### PR TITLE
File model tried to call instance on a symbol (Paperclip 3.4?)

### DIFF
--- a/app/models/cms/file.rb
+++ b/app/models/cms/file.rb
@@ -22,9 +22,11 @@ class Cms::File < ActiveRecord::Base
   has_attached_file :file, ComfortableMexicanSofa.config.upload_file_options.merge(
     # dimensions accessor needs to be set before file assignment for this to work
     :styles => lambda { |f|
-      (f.instance.dimensions.blank?? { } : { :original => f.instance.dimensions }).merge(
-        :cms_thumb => '80x60#'
-      )
+      if f.respond_to?(:instance) && f.instance.respond_to?(:dimensions)
+        (f.instance.dimensions.blank?? { } : { :original => f.instance.dimensions }).merge(
+          :cms_thumb => '80x60#'
+        )
+      end
     }
   )
   before_post_process :is_image?


### PR DESCRIPTION
Raises exception when uploading a file to S3: `undefined method 'instance' for :original:Symbol`.

I couldn't figure out why it was happening exactly (tried to trace it with pry-stack_explorer).

Here's what I added to my `config/initializers/comfortable_mexican_sofa.rb` to get S3 working:

``` ruby
  config.upload_file_options = {
    storage: :s3,
    s3_credentials: {
      bucket:              ENV['AWS_BUCKET'],
      access_key_id:       ENV['AWS_KEY'],
      secret_access_key:   ENV['AWS_SECRET']
    }
  }
```

Checking `if f.respond_to? :instance` fixes it.

All tests passing.
