### PR TITLE
Make "content" of Cms::Block larger than "text"

### DIFF
--- a/db/migrate/01_create_cms.rb
+++ b/db/migrate/01_create_cms.rb
@@ -61,7 +61,7 @@ class CreateCms < ActiveRecord::Migration
     create_table :cms_blocks do |t|
       t.integer   :page_id,     :null => false
       t.string    :identifier,  :null => false
-      t.text      :content
+      t.text      :content,     text_limit
       t.timestamps
     end
     add_index :cms_blocks, [:page_id, :identifier]


### PR DESCRIPTION
We had a problem on one site when there was really large "Content" part. This content was cutted off and we didn't see it on "Edit Page" but the page was saved correctly and had this content. It was cutted in Cms::Block. Probably it would be a good solution to increase limit of "content" in "cms_blocks" (MySQL mediumtext instead of text).
