### PR TITLE
Fix cms_snippet_tag when there is no request

### DIFF
--- a/lib/comfortable_mexican_sofa/view_methods.rb
+++ b/lib/comfortable_mexican_sofa/view_methods.rb
@@ -15,7 +15,11 @@ module ComfortableMexicanSofa::ViewMethods
   # Content of a snippet. Example:
   #   cms_snippet_content(:my_snippet)
   def cms_snippet_content(identifier, cms_site = nil)
-    return '' unless cms_site ||= (@cms_site || Cms::Site.find_site(request.host.downcase, request.fullpath))
+    unless cms_site
+      host, path = request.host.downcase, request.fullpath if respond_to?(:request) && request
+      cms_site ||= (@cms_site || Cms::Site.find_site(host, path))
+    end
+    return '' unless cms_site 
     case identifier
     when Cms::Snippet
       snippet = identifier

--- a/test/unit/view_methods_test.rb
+++ b/test/unit/view_methods_test.rb
@@ -6,12 +6,22 @@ class ViewMethodsTest < ActionView::TestCase
   
   class ::HelpersTestController < ActionController::Base
     helper { def hello; 'hello' end }
+
     def test_cms_snippet_content
       render :inline => '<%= cms_snippet_content(:default) %>'
     end
+
     def test_cms_page_content
       @cms_page = Cms::Page.root
       render :inline => '<%= cms_page_content(:default_field_text) %>'
+    end
+  end
+
+  class ::HelperTestMailer < ActionMailer::Base
+    def test_cms_snippet_content_in_mailer
+      mail(:to => "a@test.com", :subject => "test") do |format|
+        format.text { render :inline => '<%= cms_snippet_content(:default) %>' }
+      end
     end
   end
   
@@ -19,7 +29,15 @@ class ViewMethodsTest < ActionView::TestCase
   def action_result(action)
     HelpersTestController.action(action).call(ActionController::TestRequest.new.env).last.body
   end
-  
+
+  def mail_result(mail)
+    HelperTestMailer.send(mail).body.to_s
+  end
+
+  def test_cms_snippet_content_in_mailer
+    assert_equal 'default_snippet_content', mail_result('test_cms_snippet_content_in_mailer')
+  end
+
   def test_cms_snippet_content
     assert_equal 'default_snippet_content', action_result('test_cms_snippet_content')
   end


### PR DESCRIPTION
Sometimes there is no request, e.g. when rendering a mailer view.
