### PR TITLE
Fix import of pages with attribute :is_published=false 

### DIFF
--- a/lib/comfortable_mexican_sofa/fixtures.rb
+++ b/lib/comfortable_mexican_sofa/fixtures.rb
@@ -101,7 +101,7 @@ module ComfortableMexicanSofa::Fixtures
           page.label = attributes[:label] || slug.titleize
           page.layout = site.layouts.find_by_identifier(attributes[:layout]) || parent.try(:layout)
           page.target_page = site.pages.find_by_full_path(attributes[:target_page])
-          page.is_published = attributes[:is_published].present?? attributes[:is_published] : true
+          page.is_published = attributes[:is_published].nil?? true : attributes[:is_published]
           page.position = attributes[:position] if attributes[:position]
         end
       elsif page.new_record?


### PR DESCRIPTION
When importing a site from fixtures, all pages end up with :is_published set to true, regardless of what is in the fixtures directory. 

This is due to .present? mishandling 'false', treating it [the same way it handles nil and empty strings](http://api.rubyonrails.org/classes/Object.html#method-i-blank-3F). 

Instead, we can use attributes[:is_published].nil? to catch values that are not present, allowing 'true' and 'false' to pass through correctly. 
