### PR TITLE
Added config.enable_catch_all

### DIFF
--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -3,49 +3,49 @@
 ComfortableMexicanSofa.configure do |config|
   # Title of the admin area
   #   config.cms_title = 'ComfortableMexicanSofa CMS Engine'
-  
+
   # Module responsible for authentication. You can replace it with your own.
   # It simply needs to have #authenticate method. See http_auth.rb for reference.
   #   config.admin_auth = 'ComfortableMexicanSofa::HttpAuth'
-  
+
   # Module responsible for public authentication. Similar to the above. You also
   # will have access to @cms_site, @cms_layout, @cms_page so you can use them in
   # your logic. Default module doesn't do anything.
   #   config.public_auth = 'ComfortableMexicanSofa::DummyAuth'
-  
-  # Default url to access admin area is http://yourhost/cms-admin/ 
+
+  # Default url to access admin area is http://yourhost/cms-admin/
   # You can change 'cms-admin' to 'admin', for example. To disable admin area
   # entirely set this to '' or nil
   #   config.admin_route_prefix = 'cms-admin'
-  
+
   # When arriving at /cms-admin you may chose to redirect to arbirtary path,
   # for example '/cms-admin/users'
   #   config.admin_route_redirect = ''
-  
+
   # Normally we include default routes from https://github.com/comfy/comfortable-mexican-sofa/blob/master/config/routes.rb
   # If you want to include the routes manually set this to false
   #   config.use_default_routes = true
-  
+
   # /sitemap.xml that is used by search engines for indexing. It's enabled by
   # default, but you may turn it off.
   #   config.enable_sitemap = true
-  
+
   # File uploads use Paperclip and can support filesystem or s3 uploads.  Override
   # the upload method and appropriate settings based on Paperclip.  For S3 see:
-  # http://rdoc.info/gems/paperclip/2.3.8/Paperclip/Storage/S3, and for 
+  # http://rdoc.info/gems/paperclip/2.3.8/Paperclip/Storage/S3, and for
   # filesystem see: http://rdoc.info/gems/paperclip/2.3.8/Paperclip/Storage/Filesystem
   # If you are using S3 and HTTPS, pass :s3_protocol => '' to have URLs that use the protocol of the page
   #   config.upload_file_options = {:url => '/system/:class/:id/:attachment/:style/:filename'}
-  
+
   # Sofa allows you to setup entire site from files. Database is updated with each
   # request (if necessary). Please note that database entries are destroyed if there's
   # no corresponding file. Fixtures are disabled by default.
   #   config.enable_fixtures = false
-  
+
   # Path where fixtures can be located.
   #   config.fixtures_path = File.expand_path('db/cms_fixtures', Rails.root)
-  
-  # Importing fixtures into Database  
+
+  # Importing fixtures into Database
   # To load fixtures into the database just run this rake task:
   #   local: $ rake comfortable_mexican_sofa:fixtures:import FROM=example.local TO=localhost
   #   Heroku: $ heroku run rake comfortable_mexican_sofa:fixtures:import FROM=example.local TO=yourapp.herokuapp.com
@@ -56,48 +56,52 @@ ComfortableMexicanSofa.configure do |config|
   #   local: $ rake comfortable_mexican_sofa:fixtures:export FROM=localhost TO=example.local
   #   Heroku: $ heroku run rake comfortable_mexican_sofa:fixtures:export FROM=yourapp.herokuapp.com TO=example.local
   # This will create example.local folder and dump all content from example.com Site.
-  
+
   # Content for Layouts, Pages and Snippets has a revision history. You can revert
   # a previous version using this system. You can control how many revisions per
   # object you want to keep. Set it to 0 if you wish to turn this feature off.
   #   config.revisions_limit = 25
-  
+
   # Locale definitions. If you want to define your own locale merge
   # {:locale => 'Locale Title'} with this.
   #   config.locales = {:en => 'English', :es => 'Español'}
-  
+
   # Admin interface will respect the locale of the site being managed. However you can
   # force it to English by setting this to `:en`
   #   config.admin_locale = nil
-  
+
   # If you want to keep your CMS tables in a location other than the default database
   # add a database_config. For example, setting it to 'cms' will look for a cms_#{Rails.env}
   # definition in your database.yml file
   #   config.database_config = nil
-  
+
   # A class that is included as a sweeper to admin base controller if it's set
   #   config.admin_cache_sweeper = nil
-  
+
   # By default you cannot have irb code inside your layouts/pages/snippets.
   # Generally this is to prevent putting something like this:
   # <% User.delete_all %> but if you really want to allow it...
   #   config.allow_irb = false
-  
+
   # Whitelist of all helper methods that can be used via {{cms:helper}} tag. By default
   # all helpers are allowed except `eval`, `send`, `call` and few others. Empty array
   # will prevent rendering of all helpers.
   #   config.allowed_helpers = nil
-  
+
   # Whitelist of partials paths that can be used via {{cms:partial}} tag. All partials
   # are accessible by default. Empty array will prevent rendering of all partials.
   #   config.allowed_partials = nil
-  
-  # Site aliases, if you want to have aliases for your site. Good for harmonizing 
+
+  # Site aliases, if you want to have aliases for your site. Good for harmonizing
   # production env with dev/testing envs.
   # e.g. config.hostname_aliases = {'host.com' => 'host.inv', 'host_a.com' => ['host.lvh.me', 'host.dev']}
   # Default is nil (not used)
   #   config.hostname_aliases = nil
-  
+
+  # Ability to activate or deactivate the feature catching all routes
+  # and searching for cms pages. True by default, set to false if you
+  # only use comfortable_mexican_sofa for a limited number of known pages.
+  #   config.enable_catch_all = false
 end
 
 # Default credentials for ComfortableMexicanSofa::HttpAuth

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,19 +30,21 @@ Rails.application.routes.draw do
       get 'dialog/:type' => 'dialogs#show', :as => 'dialog'
     end
   end unless ComfortableMexicanSofa.config.admin_route_prefix.blank?
-  
+
   scope :controller => :cms_content do
     get 'cms-css/:site_id/:identifier' => :render_css,  :as => 'cms_css'
     get 'cms-js/:site_id/:identifier'  => :render_js,   :as => 'cms_js'
-    
+
     if ComfortableMexicanSofa.config.enable_sitemap
       get '(:cms_path)/sitemap' => :render_sitemap,
         :as           => 'cms_sitemap',
         :constraints  => {:format => /xml/},
         :format       => :xml
     end
-    
-    get '/' => :render_html,  :as => 'cms_html',  :path => "(*cms_path)"
+
+    if ComfortableMexicanSofa.config.enable_catch_all
+      get '/' => :render_html,  :as => 'cms_html',  :path => "(*cms_path)"
+    end
   end
-  
+
 end if ComfortableMexicanSofa.config.use_default_routes

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -75,6 +75,10 @@ class ComfortableMexicanSofa::Configuration
   # Default is nil (not used)
   attr_accessor :hostname_aliases
 
+  # Ability to activate or deactivate the feature catching all routes
+  # and searching for cms pages. True by default.
+  attr_accessor :enable_catch_all
+
   # Configuration defaults
   def initialize
     @cms_title            = 'ComfortableMexicanSofa CMS Engine'
@@ -108,6 +112,7 @@ class ComfortableMexicanSofa::Configuration
     @allowed_helpers      = nil
     @allowed_partials     = nil
     @hostname_aliases     = nil
+    @enable_catch_all     = true
   end
 
 end


### PR DESCRIPTION
Hi,

I added a feature to deactivate the catch-all (described here https://github.com/comfy/comfortable-mexican-sofa/wiki/How-to-protect-other-engines-from-catch-all-route) by doing

``` ruby
config.enable_catch_all = false
```

in the initializer.

I need this because I'm using cms for only a subset of my site: I have a fixed number of pages and I will never link them dynamically, so I don't need the catch-all.

If it stays activated, I get an overhead every time someone 404s because it will first check the database to see if a CMS page exists. This seems minor, but when bots crawl the site randomly or when an asset is missing on all pages this makes for a lot of useless call.

Disabling the catch-all for good would fix this. This is perfectly retrocompatible as it defaults to "true" and keeps the same logic as before.

Let me know what you think

Cheers
