### PR TITLE
resolving bug in ComfortableMexicanSofa::Fixtures.import_all

### DIFF
--- a/lib/comfortable_mexican_sofa/fixtures.rb
+++ b/lib/comfortable_mexican_sofa/fixtures.rb
@@ -1,8 +1,8 @@
 module ComfortableMexicanSofa::Fixtures
   
   def self.import_all(to_site, from_folder = nil, force_import = false)
-    import_layouts  to_site, from_folder, force_import
-    import_pages    to_site, from_folder, force_import
+    import_layouts  to_site, from_folder, nil, true, nil, [], force_import
+    import_pages    to_site, from_folder, nil, true, nil, [], force_import
     import_snippets to_site, from_folder, force_import
   end
   


### PR DESCRIPTION
Hi
It seems like a bug in `ComfortableMexicanSofa::Fixtures.import_all` method

/lib/comfortable_mexican_sofa/fixtures.rb

``` ruby
def self.import_all(to_site, from_folder = nil, force_import = false)
    import_layouts  to_site, from_folder, force_import
    import_pages    to_site, from_folder, force_import
    import_snippets to_site, from_folder, force_import
end
```

But the definition of `import_layouts` method expects these args:

``` ruby
def self.import_layouts(to_site, from_folder = nil, path = nil, root = true, parent = nil, layout_ids = [], force_import = false)
```

In case when we importing data from fixtures, the initial value of `path` variable will be `true`. And after that all things in that method going wrong.
