### PR TITLE
required jquery-rails 2.1.4 instead of 2.2. So we don't need jquery 1.9.

### DIFF
--- a/comfortable_mexican_sofa.gemspec
+++ b/comfortable_mexican_sofa.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'active_link_to', '>= 1.0.0'
   s.add_dependency 'paperclip',      '>= 3.4.0'
   s.add_dependency 'redcarpet',      '>= 2.2.0'
-  s.add_dependency 'jquery-rails',   '>= 2.2.0'
+  s.add_dependency 'jquery-rails',   '>= 2.1.4'
   s.add_dependency 'haml-rails',     '>= 0.3.0'
   s.add_dependency 'sass-rails',     '>= 3.1.0'
   s.add_dependency 'coffee-rails',   '>= 3.1.0'


### PR DESCRIPTION
Lots of nice changes in couple of months :)

But I couldn't figure out why comfy is requiring jquery 1.9. It's still quite fresh so most of the other javascript plugins are not ready for it. I'd rather wait couple more months before upgrading production env to jquery 1.9.
