### PR TITLE
Use ActiveSupport::Logger instead of ActiveSupport::BufferedLogger in AS4

### DIFF
--- a/lib/comfortable_mexican_sofa/extensions/rails.rb
+++ b/lib/comfortable_mexican_sofa/extensions/rails.rb
@@ -16,7 +16,9 @@ module Enumerable
   end
 end
 
-class ActiveSupport::BufferedLogger
+ActiveSupportLogger = ActiveSupport::VERSION::MAJOR >= 4 ?
+  ActiveSupport::Logger : ActiveSupport::BufferedLogger
+class ActiveSupportLogger
   def detailed_error(e)
     error(e.message)
     e.backtrace.each{|line| error line }


### PR DESCRIPTION
- Use ActiveSupport::Logger
  - ActiveSupport::BufferedLogger is deprecated
    - Dropped in AS4
