### PR TITLE
Allow pre-setting snippet values from URL

### DIFF
--- a/app/controllers/cms_admin/snippets_controller.rb
+++ b/app/controllers/cms_admin/snippets_controller.rb
@@ -13,6 +13,9 @@ class CmsAdmin::SnippetsController < CmsAdmin::BaseController
   end
 
   def edit
+    # This allows pre-setting snippet values from edit URL:
+    @snippet.attributes = snippet_params
+
     render
   end
 


### PR DESCRIPTION
This allows pre-setting snippet values from edit URL.
(my use case: pre-fill mirrored snippets that are created with no content).

Note that `attributes=` merges attributes (despite what `=` might suggest)
