### PR TITLE
Fix preview format (rails 4)

### DIFF
--- a/app/controllers/cms_admin/pages_controller.rb
+++ b/app/controllers/cms_admin/pages_controller.rb
@@ -106,7 +106,9 @@ protected
       @cms_site   = @page.site
       @cms_layout = @page.layout
       @cms_page   = @page
-      render :inline => @page.content(true), :layout => layout
+      respond_to do |format|
+        format.html { render inline: @page.content(true), layout: layout }
+      end
     end
   end
   


### PR DESCRIPTION
I had to do this in my rails 4 app, otherwise preview would serve zip content type and format (using `formats.last` [here](https://github.com/rails/rails/blob/a29f746398e7b0647885343e7f26d977dd251999/actionview/lib/action_view/renderer/template_renderer.rb#L14))
