### PR TITLE
adding support for template tags

### DIFF
--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -61,6 +61,10 @@ class ComfortableMexicanSofa::Configuration
   # are accessible by default. Empty array will prevent rendering of all partials.
   attr_accessor :allowed_partials
 
+  # Whitelist of template paths that can be used via {{cms:template}} tag. All templates
+  # are accessible by default. Empty array will prevent rendering of all templates.
+  attr_accessor :allowed_templates
+
   # Site aliases, if you want to have aliases for your site. Good for harmonizing
   # production env with dev/testing envs.
   # e.g. config.site_aliases = {'host.com' => 'host.inv', 'host_a.com' => ['host.lvh.me', 'host.dev']}

--- a/lib/comfortable_mexican_sofa/tags/template.rb
+++ b/lib/comfortable_mexican_sofa/tags/template.rb
@@ -1,0 +1,22 @@
+class ComfortableMexicanSofa::Tag::Template
+  include ComfortableMexicanSofa::Tag
+
+  def self.regex_tag_signature(identifier = nil)
+    identifier ||= /[\w\/\-]+/
+    /\{\{\s*cms:template:(#{identifier})\s*\}\}/
+  end
+
+  def content
+    "<%= render :template => '#{identifier}' %>"
+  end
+
+  def render
+    whitelist = ComfortableMexicanSofa.config.allowed_templates
+    if whitelist.is_a?(Array)
+      content if whitelist.member?(identifier)
+    else
+      content
+    end
+  end
+
+end


### PR DESCRIPTION
I couldn't understood why templates are not part of tags,
and also why render helper is in blacklist of helpers.

Any ways I wrote the code necessary to add support for template tags, please merge it in the main branch after a review and any possible changes.
Thank you
