### PR TITLE
adding support for template tags

### DIFF
--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -61,6 +61,10 @@ class ComfortableMexicanSofa::Configuration
   # are accessible by default. Empty array will prevent rendering of all partials.
   attr_accessor :allowed_partials
 
+  # Whitelist of template paths that can be used via {{cms:template}} tag. All templates
+  # are accessible by default. Empty array will prevent rendering of all templates.
+  attr_accessor :allowed_templates
+
   # Site aliases, if you want to have aliases for your site. Good for harmonizing
   # production env with dev/testing envs.
   # e.g. config.site_aliases = {'host.com' => 'host.inv', 'host_a.com' => ['host.lvh.me', 'host.dev']}

--- a/lib/comfortable_mexican_sofa/tags/template.rb
+++ b/lib/comfortable_mexican_sofa/tags/template.rb
@@ -1,0 +1,22 @@
+class ComfortableMexicanSofa::Tag::Template
+  include ComfortableMexicanSofa::Tag
+
+  def self.regex_tag_signature(identifier = nil)
+    identifier ||= /[\w\/\-]+/
+    /\{\{\s*cms:template:(#{identifier})\s*\}\}/
+  end
+
+  def content
+    "<%= render :template => '#{identifier}' %>"
+  end
+
+  def render
+    whitelist = ComfortableMexicanSofa.config.allowed_templates
+    if whitelist.is_a?(Array)
+      content if whitelist.member?(identifier)
+    else
+      content
+    end
+  end
+
+end

--- a/test/models/tags/template_test.rb
+++ b/test/models/tags/template_test.rb
@@ -1,0 +1,56 @@
+require_relative '../../test_helper'
+
+class TemplateTagTest < ActiveSupport::TestCase
+
+  def test_initialize_tag
+    assert tag = ComfortableMexicanSofa::Tag::Template.initialize_tag(
+      cms_pages(:default), '{{ cms:template:template_name }}'
+    )
+    assert_equal 'template_name', tag.identifier
+    assert tag = ComfortableMexicanSofa::Tag::Template.initialize_tag(
+      cms_pages(:default), '{{cms:template:path/to/template}}'
+    )
+    assert_equal 'path/to/template', tag.identifier
+    assert tag = ComfortableMexicanSofa::Tag::Template.initialize_tag(
+      cms_pages(:default), '{{cms:template:path/to/dashed-template}}'
+    )
+    assert_equal 'path/to/dashed-template', tag.identifier
+  end
+
+  def test_initialize_tag_failure
+    [
+      '{{cms:template}}',
+      '{{cms:not_template:label}}',
+      '{not_a_tag}'
+    ].each do |tag_signature|
+      assert_nil ComfortableMexicanSofa::Tag::Template.initialize_tag(
+        cms_pages(:default), tag_signature
+      )
+    end
+  end
+
+  def test_content_and_render
+    tag = ComfortableMexicanSofa::Tag::Template.initialize_tag(
+      cms_pages(:default), '{{cms:template:path/to/template}}'
+    )
+    assert_equal "<%= render :template => 'path/to/template' %>", tag.content
+    assert_equal "<%= render :template => 'path/to/template' %>", tag.render
+  end
+
+  def test_whitelisted_paths
+    ComfortableMexicanSofa.config.allowed_templates = ['safe/path']
+
+    tag = ComfortableMexicanSofa::Tag::Template.initialize_tag(
+      cms_pages(:default), '{{cms:template:safe/path}}'
+    )
+    assert_equal "<%= render :template => 'safe/path' %>", tag.content
+    assert_equal "<%= render :template => 'safe/path' %>", tag.render
+
+    tag = ComfortableMexicanSofa::Tag::Template.initialize_tag(
+      cms_pages(:default), '{{cms:template:unsafe/path}}'
+    )
+    assert_equal "<%= render :template => 'unsafe/path' %>", tag.content
+    assert_equal nil, tag.render
+  end
+
+end


### PR DESCRIPTION
I couldn't understood why templates are not part of tags,
and also why render helper is in blacklist of helpers.

Any ways I wrote the code necessary to add support for template tags, please merge it in the main branch after a review and any possible changes.
Thank you
