### PR TITLE
Allow a block of default content with cms_snippet_content

### DIFF
--- a/lib/comfortable_mexican_sofa/view_methods.rb
+++ b/lib/comfortable_mexican_sofa/view_methods.rb
@@ -12,23 +12,32 @@ module ComfortableMexicanSofa::ViewMethods
     ComfortableMexicanSofa::ViewHooks.render(name, self, options)
   end
   
-  # Content of a snippet. Example:
+  # Content of a snippet. Examples:
   #   cms_snippet_content(:my_snippet)
-  def cms_snippet_content(identifier, cms_site = nil)
+  #   <%= cms_snippet_content(:my_snippet) do %>
+  #     Default content can go here.
+  #   <% end %>
+  def cms_snippet_content(identifier, cms_site = nil, &block)
     unless cms_site
       host, path = request.host.downcase, request.fullpath if respond_to?(:request) && request
       cms_site ||= (@cms_site || Cms::Site.find_site(host, path))
     end
-    return '' unless cms_site 
-    case identifier
-    when Cms::Snippet
-      snippet = identifier
-    else
-      return '' unless snippet = cms_site.snippets.find_by_identifier(identifier)
+    return '' unless cms_site && identifier.present?
+    snippet = case identifier
+              when Cms::Snippet
+                identifier
+              else
+                cms_site.snippets.find_by_identifier(identifier)
+              end
+
+    if !snippet && block_given?
+      snippet = cms_site.snippets.create(:identifier => identifier,
+                                         :label => identifier.to_s.titleize,
+                                         :content => capture(&block))
     end
     render :inline => ComfortableMexicanSofa::Tag.process_content(cms_site.pages.build, snippet.content)
   end
-  
+
   # Content of a page block. This is how you get content from page:field
   # Example:
   #   cms_page_content(:left_column, CmsPage.first)

--- a/test/models/view_methods_test.rb
+++ b/test/models/view_methods_test.rb
@@ -11,6 +11,12 @@ class ViewMethodsTest < ActionView::TestCase
       render :inline => '<%= cms_snippet_content(:default) %>'
     end
 
+    def test_cms_snippet_with_default_content_block
+      render :inline => '<%= cms_snippet_content(:nonexistent_snippet) do %>
+                           Some content <b>here</b>.
+                         <% end %>'
+    end
+
     def test_cms_page_content
       @cms_page = Cms::Page.root
       render :inline => '<%= cms_page_content(:default_field_text) %>'
@@ -50,6 +56,23 @@ class ViewMethodsTest < ActionView::TestCase
   def test_cms_snippet_content_with_file_tag
     cms_snippets(:default).update_column(:content, '{{cms:file:sample.jpg}}')
     assert_equal cms_files(:default).file.url, action_result('test_cms_snippet_content')
+  end
+
+  def test_cms_snippet_with_default_content_block_displays_content
+    assert_equal 'Some content <b>here</b>.',
+                action_result('test_cms_snippet_with_default_content_block').strip
+  end
+
+  def test_cms_snippet_with_default_content_creates_snippet
+    assert_nil Cms::Snippet.find_by_identifier('nonexistent_snippet')
+    action_result('test_cms_snippet_with_default_content_block')
+    assert_not_nil Cms::Snippet.find_by_identifier('nonexistent_snippet')
+  end
+
+  def test_cms_snippet_with_default_content_shows_stored_snippet_if_present
+    cms_snippets(:default).update_attribute(:identifier, 'nonexistent_snippet')
+    assert_equal 'default_snippet_content',
+                 action_result('test_cms_snippet_with_default_content_block')
   end
   
   def test_cms_page_content


### PR DESCRIPTION
If such a block is given, first an attempt is made to find a matching Cms::Snippet, if one is found its content is displayed (current behavior unchanged).  If no Cms::Snippet is found, a new one is created using the content captured from the block.
### Rationale

A common pattern in our work is adding new snippets to sites after they have been launched.  Rather than the current need to both add the snippet call to the code & remember to create it in the production database, this allows for this all to happen directly from the code.
