### PR TITLE
Split out the functionality of cms_page_content.

### DIFF
--- a/lib/comfortable_mexican_sofa/view_methods.rb
+++ b/lib/comfortable_mexican_sofa/view_methods.rb
@@ -1,17 +1,17 @@
 module ComfortableMexicanSofa::ViewMethods
-  
+
   # Wrapper around ComfortableMexicanSofa::FormBuilder
   def comfy_form_for(record, options = {}, &proc)
     options[:builder] = ComfortableMexicanSofa::FormBuilder
     options[:type] ||= :horizontal
     formatted_form_for(record, options, &proc)
   end
-  
+
   # Injects some content somewhere inside cms admin area
   def cms_hook(name, options = {})
     ComfortableMexicanSofa::ViewHooks.render(name, self, options)
   end
-  
+
   # Content of a snippet. Example:
   #   cms_snippet_content(:my_snippet)
   def cms_snippet_content(identifier, cms_site = nil)
@@ -19,7 +19,7 @@ module ComfortableMexicanSofa::ViewMethods
       host, path = request.host.downcase, request.fullpath if respond_to?(:request) && request
       cms_site ||= (@cms_site || Cms::Site.find_site(host, path))
     end
-    return '' unless cms_site 
+    return '' unless cms_site
     case identifier
     when Cms::Snippet
       snippet = identifier
@@ -28,7 +28,33 @@ module ComfortableMexicanSofa::ViewMethods
     end
     render :inline => ComfortableMexicanSofa::Tag.process_content(cms_site.pages.build, snippet.content)
   end
-  
+
+  # Content of a text based page block. This is the typical method for retrieving content from
+  # page:field. Note: This method will be faster than the more generic cms_page_content.
+  #
+  # Example:
+  #   cms_page_block_content(:left_column, CmsPage.first)
+  #   cms_page_block_content(:left_column) if @cms_page is present
+  def cms_page_block_content(identifier, page = nil)
+    return '' unless page ||= @cms_page
+    return '' unless block = page.blocks.find_by_identifier(identifier)
+
+    ComfortableMexicanSofa::Tag.process_content(page, block.content)
+  end
+
+  # Fetch files from a page:field. Will return a list of files, regardless of how many files are present.
+  # Note: This method will be faster than the more generic cms_page_content.
+  #
+  # Example:
+  #   cms_page_block_content(:open_graph_image, CmsPage.first)
+  #   cms_page_block_content(:attachments, CmsPage.first)
+  def cms_page_files(identifier, page = nil)
+    return nil unless page ||= @cms_page
+    return nil unless block = page.blocks.find_by_identifier(identifier)
+
+    block.files
+  end
+
   # Content of a page block. This is how you get content from page:field
   # Example:
   #   cms_page_content(:left_column, CmsPage.first)

--- a/test/models/view_methods_test.rb
+++ b/test/models/view_methods_test.rb
@@ -1,14 +1,19 @@
 require_relative '../test_helper'
 
 class ViewMethodsTest < ActionView::TestCase
-  
+
   include ComfortableMexicanSofa::ViewMethods
-  
+
   class ::HelpersTestController < ActionController::Base
     helper { def hello; 'hello' end }
 
     def test_cms_snippet_content
       render :inline => '<%= cms_snippet_content(:default) %>'
+    end
+
+    def test_cms_page_block_content
+      @cms_page = Cms::Page.root
+      render :inline => '<%= cms_page_block_content(:default_field_text) %>'
     end
 
     def test_cms_page_content
@@ -24,7 +29,7 @@ class ViewMethodsTest < ActionView::TestCase
       end
     end
   end
-  
+
   # Simulating a call and getting resulting output
   def action_result(action)
     HelpersTestController.action(action).call(ActionController::TestRequest.new.env).last.body
@@ -41,26 +46,47 @@ class ViewMethodsTest < ActionView::TestCase
   def test_cms_snippet_content
     assert_equal 'default_snippet_content', action_result('test_cms_snippet_content')
   end
-  
+
   def test_cms_snippet_content_with_tags
     cms_snippets(:default).update_columns(:content => '{{cms:helper:hello}}')
     assert_equal 'hello', action_result('test_cms_snippet_content')
   end
-  
+
   def test_cms_snippet_content_with_file_tag
     cms_snippets(:default).update_column(:content, '{{cms:file:sample.jpg}}')
     assert_equal cms_files(:default).file.url, action_result('test_cms_snippet_content')
   end
-  
+
+  def test_cms_page_block_content
+    assert_equal 'default_field_text_content', action_result('test_cms_page_block_content')
+  end
+
+  def test_cms_page_files
+    page = cms_pages(:default)
+    page.layout.update_column(:content, '{{cms:page_files:files}}')
+    page.update_attributes!(
+      :blocks_attributes => [
+        {
+          :identifier => 'files',
+          :content    => [
+            fixture_file_upload('files/image.jpg', "image/jpeg"),
+            fixture_file_upload('files/image.gif', "image/gif")
+          ]
+        }
+      ]
+    )
+    assert_equal page.blocks.find_by_identifier('files').files, cms_page_files(:files, page)
+  end
+
   def test_cms_page_content
     assert_equal 'default_field_text_content', action_result('test_cms_page_content')
   end
-  
+
   def test_cms_page_content_with_tags
     cms_blocks(:default_field_text).update_column(:content, '{{cms:helper:hello}}')
     assert_equal 'hello', action_result('test_cms_page_content')
   end
-  
+
   def test_cms_page_content_with_files
     page = cms_pages(:default)
     page.layout.update_column(:content, '{{cms:page_file:file}} {{cms:page_files:files}}')
@@ -76,5 +102,5 @@ class ViewMethodsTest < ActionView::TestCase
     assert_equal page.blocks.find_by_identifier('file').files.first, cms_page_content(:file, page)
     assert_equal page.blocks.find_by_identifier('files').files, cms_page_content(:files, page)
   end
-  
+
 end


### PR DESCRIPTION
cms_page_content was very slow due to having to determine the type of content it was tasked with retrieving. Furthermore, the method would behave differently based on what content was being fetched. As such, it wasn't much of a stretch to split the method into two distinct methods.

Here are some benchmarks I hastily threw together to demonstrate the issue we encountered. On the left, is the  improved time using the simplified `cms_page_block_content`. On the right, the original `cms_page_content`. These tests are from a single call to fetch a title attribute on a page.

``` ruby
10.times { puts Benchmark.realtime {  cms_page_block_content(:title, page) }}
10.times { puts Benchmark.realtime {  cms_page_content(:title, page) }}
```

| `cms_page_block_content` | `cms_page_content` |
| --- | :-- |
| 0.001983987 | 0.082126979 |
| 0.000932087 | 0.019158611 |
| 0.00088599 | 0.019236887 |
| 0.000915634 | 0.019011066 |
| 0.000876496 | 0.018797225 |
| 0.000875165 | 0.018484832 |
| 0.000876062 | 0.018826148 |
| 0.000731387 | 0.018377427 |
| 0.000420175 | 0.018929082 |
| 0.000453011 | 0.018578592 |

The performance hit comes from having to determine the tag type of the content. Anecdotally, this change dropped our rendering times for the homepage of our website from 1s to 120ms. 
