### PR TITLE
Check #blocks_attributes_changed when importing pages.

### DIFF
--- a/lib/comfortable_mexican_sofa/fixture/page.rb
+++ b/lib/comfortable_mexican_sofa/fixture/page.rb
@@ -57,7 +57,7 @@ module ComfortableMexicanSofa::Fixture::Page
         page.blocks_attributes = blocks_attributes if blocks_attributes.present?
         
         # saving
-        if page.changed? || self.force_import
+        if page.changed? || page.blocks_attributes_changed || self.force_import
           if page.save
             save_categorizations!(page, categories)
             ComfortableMexicanSofa.logger.warn("[FIXTURES] Imported Page \t #{page.full_path}")


### PR DESCRIPTION
Since the fixtures rewrite, this extra check when deciding whether or not to save pages when importing fixtures had gone missing.

This also applies to the 1.8 branch.

Sorry about the whitespace; I blame GitHub’s editor.
