### PR TITLE
Moved establish_connection to a base class

### DIFF
--- a/app/models/cms/block.rb
+++ b/app/models/cms/block.rb
@@ -1,6 +1,4 @@
-class Cms::Block < ActiveRecord::Base
-  
-  ComfortableMexicanSofa.establish_connection(self)
+class Cms::Block < ComfortableMexicanSofa::Base
   
   self.table_name = 'cms_blocks'
   

--- a/app/models/cms/categorization.rb
+++ b/app/models/cms/categorization.rb
@@ -1,6 +1,4 @@
-class Cms::Categorization < ActiveRecord::Base
-  
-  ComfortableMexicanSofa.establish_connection(self)
+class Cms::Categorization < ComfortableMexicanSofa::Base
   
   self.table_name = 'cms_categorizations'
   

--- a/app/models/cms/category.rb
+++ b/app/models/cms/category.rb
@@ -1,6 +1,4 @@
-class Cms::Category < ActiveRecord::Base
-  
-  ComfortableMexicanSofa.establish_connection(self)
+class Cms::Category < ComfortableMexicanSofa::Base
   
   self.table_name = 'cms_categories'
   

--- a/app/models/cms/file.rb
+++ b/app/models/cms/file.rb
@@ -1,8 +1,6 @@
-class Cms::File < ActiveRecord::Base
+class Cms::File < ComfortableMexicanSofa::Base
   
   IMAGE_MIMETYPES = %w(gif jpeg pjpeg png svg+xml tiff).collect{|subtype| "image/#{subtype}"}
-  
-  ComfortableMexicanSofa.establish_connection(self)
     
   self.table_name = 'cms_files'
   

--- a/app/models/cms/layout.rb
+++ b/app/models/cms/layout.rb
@@ -1,6 +1,4 @@
-class Cms::Layout < ActiveRecord::Base
-  
-  ComfortableMexicanSofa.establish_connection(self)
+class Cms::Layout < ComfortableMexicanSofa::Base
     
   self.table_name = 'cms_layouts'
   

--- a/app/models/cms/page.rb
+++ b/app/models/cms/page.rb
@@ -1,8 +1,6 @@
 # encoding: utf-8
 
-class Cms::Page < ActiveRecord::Base
-  
-  ComfortableMexicanSofa.establish_connection(self)
+class Cms::Page < ComfortableMexicanSofa::Base
     
   self.table_name = 'cms_pages'
   

--- a/app/models/cms/revision.rb
+++ b/app/models/cms/revision.rb
@@ -1,6 +1,4 @@
-class Cms::Revision < ActiveRecord::Base
-  
-  ComfortableMexicanSofa.establish_connection(self)
+class Cms::Revision < ComfortableMexicanSofa::Base
   
   self.table_name = 'cms_revisions'
   

--- a/app/models/cms/site.rb
+++ b/app/models/cms/site.rb
@@ -1,6 +1,4 @@
-class Cms::Site < ActiveRecord::Base
-  
-  ComfortableMexicanSofa.establish_connection(self)
+class Cms::Site < ComfortableMexicanSofa::Base
   
   self.table_name = 'cms_sites'
   

--- a/app/models/cms/snippet.rb
+++ b/app/models/cms/snippet.rb
@@ -1,7 +1,5 @@
-class Cms::Snippet < ActiveRecord::Base
-  
-  ComfortableMexicanSofa.establish_connection(self)
-  
+class Cms::Snippet < ComfortableMexicanSofa::Base
+
   self.table_name = 'cms_snippets'
   
   cms_is_categorized

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -98,3 +98,6 @@ ComfortableMexicanSofa::HttpAuth.password = 'password'
 #   ComfortableMexicanSofa::ViewHooks.add(:navigation, '/layouts/admin/navigation')
 #   ComfortableMexicanSofa::ViewHooks.add(:html_head, '/layouts/admin/html_head')
 #   ComfortableMexicanSofa::ViewHooks.add(:page_form, '/layouts/admin/page_form')
+
+# If you have a custom ComfortableMexicanSofa.config.database_config, uncomment next line
+# ComfortableMexicanSofa::Base.establish_connection

--- a/lib/comfortable_mexican_sofa.rb
+++ b/lib/comfortable_mexican_sofa.rb
@@ -49,13 +49,6 @@ module ComfortableMexicanSofa
     end
     alias :config :configuration
     
-    # Establishing database connection if custom one is defined
-    def establish_connection(klass)
-      if ComfortableMexicanSofa.config.database_config && !Rails.env.test?
-        klass.establish_connection "#{ComfortableMexicanSofa.config.database_config}_#{Rails.env}"
-      end
-    end
-
     def logger=(new_logger)
       @logger = new_logger
     end
@@ -66,3 +59,5 @@ module ComfortableMexicanSofa
     
   end
 end
+
+require_relative 'comfortable_mexican_sofa/base'

--- a/lib/comfortable_mexican_sofa/base.rb
+++ b/lib/comfortable_mexican_sofa/base.rb
@@ -1,0 +1,9 @@
+class ComfortableMexicanSofa::Base < ActiveRecord::Base
+  self.abstract_class = true
+
+  def self.establish_connection
+    if ComfortableMexicanSofa.config.database_config && !Rails.env.test?
+      super "#{ComfortableMexicanSofa.config.database_config}_#{Rails.env}"
+    end
+  end
+end


### PR DESCRIPTION
Create a ComfortableMexicanSofa::Base class which establish the connection to the database, instead of having a connection for each model. 

The idea is that all the models can share a pool of connection and avoid deadlocks when  having a custom database config. 
