### PR TITLE
Fix Page Preview for Comfy 1.8 and Rails 3.2.14

### DIFF
--- a/app/controllers/cms_admin/pages_controller.rb
+++ b/app/controllers/cms_admin/pages_controller.rb
@@ -106,7 +106,9 @@ protected
       @cms_site   = @page.site
       @cms_layout = @page.layout
       @cms_page   = @page
-      render :inline => @page.content(true), :layout => layout
+      respond_to do |format|
+        format.html { render inline: @page.content(true), layout: layout }
+      end
     end
   end
 end


### PR DESCRIPTION
Uses @glebm's fix for the preview button: https://github.com/comfy/comfortable-mexican-sofa/pull/322

Although this was fixed on Comfy 1.9 and Rails 4.0, applications still using Comfy 1.8 and the latest version of Rails 3.2 (3.2.14) have the preview button bug. 

A gem version bump to 1.8.5 for the 1.8 branch would be great.
