### PR TITLE
Backport: allowing to override admin base controller inheritance via config

### DIFF
--- a/app/controllers/cms_admin/base_controller.rb
+++ b/app/controllers/cms_admin/base_controller.rb
@@ -1,4 +1,4 @@
-class CmsAdmin::BaseController < ApplicationController
+class CmsAdmin::BaseController < ComfortableMexicanSofa.config.base_controller.to_s.constantize
 
   protect_from_forgery
 

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -4,6 +4,9 @@ ComfortableMexicanSofa.configure do |config|
   # Title of the admin area
   #   config.cms_title = 'ComfortableMexicanSofa CMS Engine'
   
+  # Controller that is inherited from CmsAdmin::BaseController
+  #   config.base_controller = 'ApplicationController'
+
   # Module responsible for authentication. You can replace it with your own.
   # It simply needs to have #authenticate method. See http_auth.rb for reference.
   #   config.admin_auth = 'ComfortableMexicanSofa::HttpAuth'

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -4,6 +4,10 @@ class ComfortableMexicanSofa::Configuration
 
   # Don't like ComfortableMexicanSofa? Set it to whatever you like. :(
   attr_accessor :cms_title
+  
+  # Controller that is inherited from CmsAdmin::BaseController
+  # 'ApplicationController' is the default
+  attr_accessor :base_controller
 
   # Module that will handle authentication to access cms-admin area
   attr_accessor :admin_auth
@@ -66,6 +70,7 @@ class ComfortableMexicanSofa::Configuration
   # Configuration defaults
   def initialize
     @cms_title            = 'ComfortableMexicanSofa CMS Engine'
+    @base_controller      = 'ApplicationController'
     @admin_auth           = 'ComfortableMexicanSofa::HttpAuth'
     @public_auth          = 'ComfortableMexicanSofa::DummyAuth'
     @seed_data_path       = nil

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -7,6 +7,7 @@ class ConfigurationTest < ActiveSupport::TestCase
   def test_configuration_presence
     assert config = ComfortableMexicanSofa.configuration
     assert_equal 'ComfortableMexicanSofa CMS Engine', config.cms_title
+    assert_equal 'ApplicationController', config.base_controller
     assert_equal 'ComfortableMexicanSofa::HttpAuth', config.admin_auth
     assert_equal 'ComfortableMexicanSofa::DummyAuth', config.public_auth
     assert_equal '', config.admin_route_redirect


### PR DESCRIPTION
(cherry picked from commit 9821e128c2368b0058576dd42cc08e07963b71ec)

Conflicts:
    config/initializers/comfortable_mexican_sofa.rb
