### PR TITLE
sanitizes irb when calling cms_page_content or cms_snippet_content

### DIFF
--- a/lib/comfortable_mexican_sofa/view_methods.rb
+++ b/lib/comfortable_mexican_sofa/view_methods.rb
@@ -35,7 +35,7 @@ module ComfortableMexicanSofa::ViewMethods
     end
     
     return '' unless snippet
-    render :inline => ComfortableMexicanSofa::Tag.process_content(cms_site.pages.build, snippet.content)
+    render :inline => ComfortableMexicanSofa::Tag.process_content(cms_site.pages.build, ComfortableMexicanSofa::Tag.sanitize_irb(snippet.content))
   end
 
   # Content of a text based page block. This is the typical method for retrieving content from
@@ -79,7 +79,7 @@ module ComfortableMexicanSofa::ViewMethods
     when ComfortableMexicanSofa::Tag::PageFiles
       block.files
     else
-      render :inline => ComfortableMexicanSofa::Tag.process_content(page, block.content)
+      render :inline => ComfortableMexicanSofa::Tag.process_content(page, ComfortableMexicanSofa::Tag.sanitize_irb(block.content))
     end
   end
 end

--- a/test/lib/view_methods_test.rb
+++ b/test/lib/view_methods_test.rb
@@ -110,7 +110,13 @@ class ViewMethodsTest < ActionView::TestCase
     assert_equal 'default_snippet_content',
       action_result('test_cms_snippet_with_default_content_block')
   end
-  
+
+  def test_cms_snippet_content_with_irb
+    cms_snippets(:default).update_column(:content, '<%= 1+1+1+1+1 %>')
+    assert_equal "&lt;%= 1+1+1+1+1 %&gt;", action_result('test_cms_snippet_content')
+  end
+
+
   def test_cms_page_content
     assert_equal 'default_field_text_content', action_result('test_cms_page_content')
   end
@@ -139,6 +145,11 @@ class ViewMethodsTest < ActionView::TestCase
     )
     assert_equal page.blocks.find_by_identifier('file').files.first, cms_page_content(:file, page)
     assert_equal page.blocks.find_by_identifier('files').files, cms_page_content(:files, page)
+  end
+
+  def test_cms_page_content_with_irb
+    cms_blocks(:default_field_text).update_column(:content, '<%= 1+1+1+1+1 %>')
+    assert_equal "&lt;%= 1+1+1+1+1 %&gt;", action_result('test_cms_page_content')
   end
 
 end


### PR DESCRIPTION
currently using snippets or page with view_method helper results in irb in the cms getting executed. It's not supposed to happen if irb executing is forbidden. See added tests.
