### PR TITLE
Fixes styling issue with using formatted_form's :prepend option

### DIFF
--- a/app/assets/stylesheets/comfortable_mexican_sofa/bootstrap_overrides.css.sass
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/bootstrap_overrides.css.sass
@@ -1,10 +1,12 @@
 $form_fields: "select, textarea, input[type='text'], input[type='password'], input[type='datetime'], input[type='datetime-local'], input[type='date'], input[type='month'], input[type='time'], input[type='week'], input[type='number'], input[type='email'], input[type='url'], input[type='search'], input[type='tel'], input[type='color'], .uneditable-input"
 
 body#comfy
-  
   h1, h2, h3, h4, h5, .page-header
     margin-top: 0
-  
+  .input-prepend
+    .add-on
+	    box-sizing: content-box;
+	    padding: 6px 4px;
   table.table
     th, td
       white-space: nowrap


### PR DESCRIPTION
The padding and box-sizing set on this element make it not aligned with its accompanying text inputs.
