### PR TITLE
Proper update of mirrored sites root pages label

### DIFF
--- a/lib/comfortable_mexican_sofa/extensions/is_mirrored.rb
+++ b/lib/comfortable_mexican_sofa/extensions/is_mirrored.rb
@@ -48,7 +48,7 @@ module ComfortableMexicanSofa::IsMirrored
           m = site.pages.find_by_full_path(self.full_path_was || self.full_path) || site.pages.new
           m.attributes = {
             :slug       => self.slug,
-            :label      => self.slug.blank?? self.label : m.label,
+            :label      => m.label.blank?? self.label : m.label,
             :parent_id  => site.pages.find_by_full_path(self.parent.try(:full_path)).try(:id),
             :layout     => site.layouts.find_by_identifier(self.layout.try(:identifier))
           }

--- a/test/lib/mirrors_test.rb
+++ b/test/lib/mirrors_test.rb
@@ -14,14 +14,26 @@ class MirrorsTest < ActiveSupport::TestCase
   def test_page_creation
     setup_sites
     layout = @site_a.layouts.create!(:identifier => 'test')
+    label = 'Root'
+    mirror_label = 'Mirror Root'
     
     assert_difference 'Cms::Page.count', 2 do
       page = @site_a.pages.create!(
         :layout => layout,
-        :label  => 'Root'
+        :label  => label
       )
+      page_mirror = page.mirrors.first
+
       assert_equal 1, page.mirrors.size
-      assert_equal '/', page.mirrors.first.full_path
+      assert_equal '/', page_mirror.full_path
+      assert_equal page_mirror.label, label
+
+      page_mirror.update_attributes!(
+        :label => mirror_label
+      )
+      page.reload
+      assert_equal page.label, label
+      assert_equal page_mirror.label, mirror_label
     end
   end
   


### PR DESCRIPTION
When root page label is updated cms mirrors that label among all mirror pages which obviously should not happen.
As I understand this problem occurs due to the pre-filling condition for the label of the new page which is created while mirror sync works. Additionally I changed mirror test a bit to show the use case when the problem appears.

It's my first pull request, hope I'm doing everything in right way
