### PR TITLE
Internationaized 'Add Category' field placeholder in 'categories/_index'

### DIFF
--- a/app/views/admin/cms/categories/_index.html.haml
+++ b/app/views/admin/cms/categories/_index.html.haml
@@ -20,5 +20,5 @@
     = form_for :category, :url => admin_cms_site_categories_path(@site), :remote => true, :html => {:id => 'new_category'} do |form|
       = form.hidden_field :categorized_type, :value => type
       .input-append
-        = form.text_field :label, :placeholder => 'Add Category'
+        = form.text_field :label, :placeholder => t('.add_placeholder')
         %button.btn.btn-mini= t('.add')

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -223,6 +223,7 @@ de:
           done: Erledigt
           all: Alle
           add: Hinzuzufügen
+          add_placeholder: Kategorie Hinzuzufügen
         show:
           are_you_sure: Sind Sie sicher?
         edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,6 +223,7 @@ en:
           done: Done
           all: All
           add: Add
+          add_placeholder: Add Category
         show:
           are_you_sure: Are you sure?
         edit:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -223,6 +223,7 @@ es:
           done: Listo
           all: Todos
           add: Agregar
+          add_placeholder: Añadir Categoría
         show:
           are_you_sure: ¿Estás seguro?
         edit:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -223,6 +223,7 @@ fr:
           done: Terminé
           all: Tout
           add: Ajouter
+          add_placeholder: Ajouter la Catégorie
         show:
           are_you_sure: Êtes-vous sûr de vouloir supprimer cette catégorie ?
         edit:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -223,6 +223,7 @@ ja:
           done: 完了
           all: すべて
           add: 追加
+          add_placeholder: カテゴリを追加
         show:
           are_you_sure: よろしいですか？
         edit:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -223,6 +223,7 @@ nl:
           done: Klaar
           all: Alle
           add: Toevoegen
+          add_placeholder: Categorie Toevoegen
         show:
           are_you_sure: Weet u het zeker?
         edit:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -223,6 +223,7 @@ pl:
           done: Zrobione
           all: Wszystko
           add: Dodaj
+          add_placeholder: Dodać Kategorię
         show:
           are_you_sure: Jesteś pewien?
         edit:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -223,6 +223,7 @@ pt-BR:
           done: Pronto
           all: Todas
           add: Adicionar
+          add_placeholder: Adicione uma Categoria
         show:
           are_you_sure: Tem certeza?
         edit:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -223,6 +223,7 @@ ru:
           done: Применить
           all: Все
           add: Добавить
+          add_placeholder: добавить категорию
         show:
           are_you_sure: Вы уверены?
         edit:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -223,6 +223,7 @@ sv:
           done: Klar
           all: Alla
           add: Lägg till
+          add_placeholder: Lägga Kategori
         show:
           are_you_sure: Är du säker?
         edit:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -223,6 +223,7 @@ zh-CN:
           done: 完成
           all: 全部
           add: 创建
+          add_placeholder: 添加类别
         show:
           are_you_sure: 确定删除该分类吗？
         edit:


### PR DESCRIPTION
I8n-ised the "Add Category" placeholder of the add category field present in the partial categories/_index.html which appears on top of pages list in Pages section of the CMS admin.

This relates to the issue #372
