### PR TITLE
Update edit.html.haml

### DIFF
--- a/app/views/admin/cms/layouts/edit.html.haml
+++ b/app/views/admin/cms/layouts/edit.html.haml
@@ -1,5 +1,5 @@
 .page-header
-  = link_to pluralize(@layout.revisions.count, t('.revision')), admin_cms_site_layout_revisions_path(@site, @layout), :class => 'btn pull-right'
+  = link_to t('.revisions', :count => @layout.revisions.count), admin_cms_site_layout_revisions_path(@site, @layout), :class => 'btn pull-right'
   %h2= t('.title')
 
 - content_for :right_column do


### PR DESCRIPTION
Pluralization in some latin languages fails otherwise. Corresponding yaml must be changed to:
en:
  admin:
    cms:
      layouts:
        edit:
          revision:
            zero: no revisions
            one: 1 revision
            other: %{count} revisions

that in Italian, for example, would be:

it:
  admin:
    cms:
      layouts:
        edit:
          revision:
            zero: nessuna revisione
            one: 1 revisione
            other: %{count} revisioni
