### PR TITLE
Changed content controller's default response type to HTML

### DIFF
--- a/app/controllers/cms/content_controller.rb
+++ b/app/controllers/cms/content_controller.rb
@@ -1,6 +1,7 @@
 class Cms::ContentController < Cms::BaseController
 
-  respond_to :json, :html
+  # Respond with HTML by default so that requests with 'Accept: */*' get a web page (e.g. Facebook)
+  respond_to :html, :json
 
   # Authentication module must have #authenticate method
   include ComfortableMexicanSofa.config.public_auth.to_s.constantize

--- a/test/controllers/cms/content_controller_test.rb
+++ b/test/controllers/cms/content_controller_test.rb
@@ -21,6 +21,12 @@ class Cms::ContentControllerTest < ActionController::TestCase
     ), response.body
     assert_equal 'text/html', response.content_type
   end
+
+  def test_show_default_html
+    @request.headers["Accept"] = "*/*"
+    get :show, :cms_path => ''
+    assert_equal 'text/html', response.content_type
+  end
   
   def test_show_as_json
     get :show, :cms_path => '', :format => 'json'


### PR DESCRIPTION
The Facebook crawler sends requests with the header `Accept: */*`, which currently makes the content controller respond with JSON. See [this stack overflow question](http://stackoverflow.com/questions/12094683/facebook-open-graph-action-rails-return-json-or-html).

This PR changes the default response content type to `text/html`, which seems reasonable for a CMS. Hopefully anyone making requests for JSON is specifying `application/json` in their `Accept` header.

EDIT: you can see what Facebook sees using their [URL linter](https://developers.facebook.com/tools/debug/).
