### PR TITLE
fixed fixture file export encoding bug

### DIFF
--- a/lib/comfortable_mexican_sofa/fixture/file.rb
+++ b/lib/comfortable_mexican_sofa/fixture/file.rb
@@ -59,7 +59,7 @@ module ComfortableMexicanSofa::Fixture::File
           file.file.path :
           file.file.url
           
-        open(::File.join(self.path, ::File.basename(file_path)), 'w') do |f|
+        open(::File.join(self.path, ::File.basename(file_path)), 'wb') do |f|
           open(data_path) { |src| f.write(src.read) }
         end
         


### PR DESCRIPTION
Was encountering [this bug with encoding](http://stackoverflow.com/questions/4988724/ruby-on-rails-upload-file-problem-odd-utf8-conversion-error) when exporting fixture files
