### PR TITLE
@cms_page available in auth

### DIFF
--- a/app/controllers/cms/content_controller.rb
+++ b/app/controllers/cms/content_controller.rb
@@ -7,14 +7,13 @@ class Cms::ContentController < Cms::BaseController
   include ComfortableMexicanSofa.config.public_auth.to_s.constantize
 
   before_action :load_fixtures
-  before_action :authenticate,
+  before_action :load_cms_page,
+                :authenticate,
                 :only => :show
 
   rescue_from ActiveRecord::RecordNotFound, :with => :page_not_found
 
   def show
-    @cms_page = @cms_site.pages.published.find_by_full_path!("/#{params[:cms_path]}")
-
     if @cms_page.target_page.present?
       redirect_to @cms_page.target_page.url
     else
@@ -43,6 +42,10 @@ protected
     return unless ComfortableMexicanSofa.config.enable_fixtures
     ComfortableMexicanSofa::Fixture::Importer.new(@cms_site.identifier).import!
   end
+  
+  def load_cms_page
+    @cms_page = @cms_site.pages.published.find_by_full_path!("/#{params[:cms_path]}")
+  end    
 
   def page_not_found
     @cms_page = @cms_site.pages.published.find_by_full_path!('/404')


### PR DESCRIPTION
This commit allows the variable:  @cms_page to be used in the authenticate method.  This functionality was supported in version 1.11.0 therefore, without this commit, some authenticate methods could break during upgrade from 1.11.0 to 1.11.1 (like mine did)
