### PR TITLE
Adding dependency directives to stylesheet to avoid DependecyError

### DIFF
--- a/app/assets/stylesheets/comfortable_mexican_sofa/base.css.sass
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/base.css.sass
@@ -1,3 +1,13 @@
+//= depend_on_asset "comfortable_mexican_sofa/checkerboard.gif"
+//= depend_on_asset "comfortable_mexican_sofa/icon_page.gif"
+//= depend_on_asset "comfortable_mexican_sofa/icon_move.gif"
+//= depend_on_asset "comfortable_mexican_sofa/arrow_bottom.gif"
+//= depend_on_asset "comfortable_mexican_sofa/arrow_right.gif"
+//= depend_on_asset "comfortable_mexican_sofa/icon_draft.gif"
+//= depend_on_asset "comfortable_mexican_sofa/icon_site.gif"
+//= depend_on_asset "comfortable_mexican_sofa/icon_layout.gif"
+//= depend_on_asset "comfortable_mexican_sofa/icon_snippet.gif"
+//= depend_on_asset "comfortable_mexican_sofa/icon_file.gif"
 html, body#comfy
   height: 100%
   

--- a/app/assets/stylesheets/comfortable_mexican_sofa/bootstrap_overrides.css.sass
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/bootstrap_overrides.css.sass
@@ -1,3 +1,5 @@
+//= depend_on_asset "comfortable_mexican_sofa/bootstrap/glyphicons-halflings.png"
+//= depend_on_asset "comfortable_mexican_sofa/bootstrap/glyphicons-halflings-white.png"
 $form_fields: "select, textarea, input[type='text'], input[type='password'], input[type='datetime'], input[type='datetime-local'], input[type='date'], input[type='month'], input[type='time'], input[type='week'], input[type='number'], input[type='email'], input[type='url'], input[type='search'], input[type='tel'], input[type='color'], .uneditable-input"
 
 body#comfy


### PR DESCRIPTION
This is actually a follow up of issue https://github.com/comfy/comfortable-mexican-sofa/issues/397. 

Please comment if there is a more efficient way of doing this.

The following pull request from the sprockets-rails gem
(https://github.com/rails/sprockets-rails/pull/96) requires that the
referenced assets be declared explicitly with the dependency directives
(i.e. the `depend_on` or `depend_on_asset` directive).

Adding the dependency directives to the affected stylesheets.
