### PR TITLE
Fix asset tag rendering css/js when the site has a path.

### DIFF
--- a/lib/comfortable_mexican_sofa/tags/asset.rb
+++ b/lib/comfortable_mexican_sofa/tags/asset.rb
@@ -13,13 +13,24 @@ class ComfortableMexicanSofa::Tag::Asset
     
     case type
     when 'css'
-      out = "/cms-css/#{blockable.site.id}/#{identifier}.css"
+      out = "/cms-css/#{blockable.site.id}/#{identifier}.css#{cms_path}"
       out = "<link href='#{out}' media='screen' rel='stylesheet' type='text/css' />" if format == 'html_tag'
       out
     when 'js'
-      out = "/cms-js/#{blockable.site.id}/#{identifier}.js"
+      out = "/cms-js/#{blockable.site.id}/#{identifier}.js#{cms_path}"
       out = "<script src='#{out}' type='text/javascript'></script>" if format == 'html_tag'
       out
+    end
+  end
+
+private
+
+  def cms_path
+    path = blockable.site.path
+    if path.present?
+      "?cms_path=#{path}"
+    else
+      ""
     end
   end
 end

--- a/test/lib/tags/asset_test.rb
+++ b/test/lib/tags/asset_test.rb
@@ -40,6 +40,13 @@ class AssetTagTest < ActiveSupport::TestCase
     )
     assert_equal "<link href='/cms-css/#{comfy_cms_sites(:default).id}/default.css' media='screen' rel='stylesheet' type='text/css' />", tag.render
   end
+
+  def test_render_for_css_when_site_has_path
+    tag = ComfortableMexicanSofa::Tag::Asset.initialize_tag(
+      page_for_site_with_path('/foo'), '{{ cms:asset:default:css }}'
+    )
+    assert_equal "/cms-css/#{comfy_cms_sites(:default).id}/default.css?cms_path=/foo", tag.render
+  end
   
   def test_render_for_js
     tag = ComfortableMexicanSofa::Tag::Asset.initialize_tag(
@@ -52,5 +59,17 @@ class AssetTagTest < ActiveSupport::TestCase
     )
     assert_equal "<script src='/cms-js/#{comfy_cms_sites(:default).id}/default.js' type='text/javascript'></script>", tag.render
   end
-  
+
+  def test_render_for_js_when_site_has_path
+    tag = ComfortableMexicanSofa::Tag::Asset.initialize_tag(
+      page_for_site_with_path('/foo'), '{{ cms:asset:default:js }}'
+    )
+    assert_equal "/cms-js/#{comfy_cms_sites(:default).id}/default.js?cms_path=/foo", tag.render
+  end
+
+  def page_for_site_with_path(path)
+    page = comfy_cms_pages(:default)
+    page.site.update_attribute(:path, path)
+    page
+  end
 end


### PR DESCRIPTION
The asset controller expects the `cms_path` to be present in the URL if the `Site` has a `path`. The asset tag does not render the `cms_path`. That means when you load your page the stylesheet and javascript 404. The approach I took was to append a query string that sets the `cms_path` when rendering the asset tag. I felt like this was the least amount of friction.

``` plain
{{ cms:asset:default:css }}
```

Becomes...

``` html
/cms-css/1/default.css?cms_path=/foo
```

To give more context I'm including snippets from the assets and base controller.

``` ruby
# app/controllers/comfy/cms/assets_controller.rb
class Comfy::Cms::AssetsController < Comfy::Cms::BaseController
  before_action :load_cms_layout

  def render_css
    render :text => @cms_layout.css, :content_type => 'text/css'
  end

  # ...

protected

  def load_cms_layout
    @cms_layout = @cms_site.layouts.find_by_identifier!(params[:identifier])
  rescue ActiveRecord::RecordNotFound
    render :nothing => true, :status => 404
  end
end
```

``` ruby
# app/controllers/comfy/cms/base_controller.rb
# ...
if @cms_site
  if @cms_site.path.present?
    if params[:cms_path] && params[:cms_path].match(/\A#{@cms_site.path}/)
      params[:cms_path].gsub!(/\A#{@cms_site.path}/, '')
      params[:cms_path] && params[:cms_path].gsub!(/\A\//, '')
    else
      raise ActionController::RoutingError.new('Site Not Found')
    end
  end
  I18n.locale = @cms_site.locale
else
  I18n.locale = I18n.default_locale
  raise ActionController::RoutingError.new('Site Not Found')
end
# ...
```

The alternative way of approaching it could be relax the restriction on paths in assets controller. The downside is you can't take advantage of the cached @cms_layout.

Open to any feedback.
