### PR TITLE
making Sprockets in Rails 4.1 cope with bootstrap-sass

### DIFF
--- a/app/assets/stylesheets/comfortable_mexican_sofa/base.css.sass
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/base.css.sass
@@ -1,3 +1,15 @@
+// hack until new bootstrap-sass fixes this
+//= depend_on_asset "comfortable_mexican_sofa/checkerboard.gif"
+//= depend_on_asset "comfortable_mexican_sofa/icon_page.gif"
+//= depend_on_asset "comfortable_mexican_sofa/icon_move.gif"
+//= depend_on_asset "comfortable_mexican_sofa/arrow_bottom.gif"
+//= depend_on_asset "comfortable_mexican_sofa/arrow_right.gif"
+//= depend_on_asset "comfortable_mexican_sofa/icon_draft.gif"
+//= depend_on_asset "comfortable_mexican_sofa/icon_site.gif"
+//= depend_on_asset "comfortable_mexican_sofa/icon_layout.gif"
+//= depend_on_asset "comfortable_mexican_sofa/icon_file.gif"
+//= depend_on_asset "comfortable_mexican_sofa/icon_snippet.gif"
+
 html, body#comfy
   height: 100%
   

--- a/app/assets/stylesheets/comfortable_mexican_sofa/bootstrap_overrides.css.sass
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/bootstrap_overrides.css.sass
@@ -1,3 +1,7 @@
+// hack until Bootstrap-Sass fixes this
+//= depend_on_asset "comfortable_mexican_sofa/bootstrap/glyphicons-halflings.png"
+//= depend_on_asset "comfortable_mexican_sofa/bootstrap/glyphicons-halflings-white.png"
+
 $form_fields: "select, textarea, input[type='text'], input[type='password'], input[type='datetime'], input[type='datetime-local'], input[type='date'], input[type='month'], input[type='time'], input[type='week'], input[type='number'], input[type='email'], input[type='url'], input[type='search'], input[type='tel'], input[type='color'], .uneditable-input"
 
 body#comfy


### PR DESCRIPTION
I added the 'sofa' to a Rails Project of mine - and Sprocket complained about missing depends_on_asset - which is why I forward this PR.

Perhaps the goal with the sofa is not aligned with my needs but anyways ;)

cheers
Walther
