### PR TITLE
Responsive UI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,9 @@ Fork the project. Optionally, create a branch you want to work on.
 
 ### 3. Hack away
 
-- Create a few small pull requests instead of a humoungous one. I can merge small stuff faster.
-- When adding new code just make sure it follows the same slyle as the existing code.
-- Avoid adding 3rd party dependencies if you can.
+- Create a few small pull requests instead of a humongous one. I can merge small stuff faster.
+- When adding new code just make sure it follows the same style as the existing code.
+- Avoid adding 3rd-party dependencies if you can.
 - Tests please, but nothing complicated. UnitTest / Fixtures all the way. Make sure all tests pass.
 
 ### 4. Make a pull request

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For more information please refer to [Wiki](https://github.com/comfy/comfortable
 
 #### Dependencies
 
-As long as you sucessfuly ran `bundle install` you should be ok. However, Paperclip requires *ImageMagick* to be installed to handle thumbnail generation.
+As long as you successfully ran `bundle install` you should be ok. However, Paperclip requires *ImageMagick* to be installed to handle thumbnail generation.
 
 #### Help and Contact
 

--- a/app/assets/stylesheets/comfortable_mexican_sofa/application.css.sass
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/application.css.sass
@@ -5,3 +5,4 @@
 @import "comfortable_mexican_sofa/bootstrap_overrides"
 @import "comfortable_mexican_sofa/codemirror_overrides"
 @import "comfortable_mexican_sofa/base"
+@import "comfortable_mexican_sofa/thin"

--- a/app/assets/stylesheets/comfortable_mexican_sofa/base.css.sass
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/base.css.sass
@@ -9,46 +9,44 @@
 //= depend_on_asset "comfortable_mexican_sofa/icon_snippet.gif"
 //= depend_on_asset "comfortable_mexican_sofa/icon_file.gif"
 
+$sidebar-width: 18%
+
 html, body#comfy
   height: 100%
-  
+
 body#comfy
   background-color: #252525
-  
+
   // -- Containers ----------------------------------------------------------
   .body-wrapper
     height: 100%
     .left-column
-      width: 175px
-      float: left
-      .left-column-content
-        padding: 25px 0px
-        width: 175px
-        position: fixed
+      padding: 25px 0px
+      width: $sidebar-width
+      position: fixed
     .center-column
       position: relative
-      margin: 0px 250px 0px 175px
+      margin: 0 $sidebar-width
       min-height: 100%
       background-color: #fff
-      .center-column-content
-        padding: 25px
+      padding: 25px
     .right-column
-      width: 250px
-      float: right
-      .right-column-content
-        padding: 25px 10px
-        width: 250px
-        position: fixed
-  
+      padding: 25px 10px
+      width: $sidebar-width
+      position: fixed
+      right: 0
+      top: 0
+
   // -- Navigation ----------------------------------------------------------
-  .left-column-content ul.navigation
+  .left-column ul.navigation
     list-style: none
     margin: 0
     padding: 0
+    text-align: right
     a
       position: relative
       display: block
-      padding: 7px 15px
+      padding: 7px 20px
       color: #777
       border-bottom: 1px solid #333
       text-decoration: none
@@ -73,9 +71,9 @@ body#comfy
       padding: 0
       a
         padding: 7px 15px 7px 30px
-  
+
   // -- Right Side Boxes ----------------------------------------------------
-  .right-column-content
+  .right-column
     .box
       background-color: #fff
       padding: 5px
@@ -88,9 +86,9 @@ body#comfy
     #form-save
       label
         padding-top: 0
-        
+
   // -- File Uploads --------------------------------------------------------
-  .right-column-content .file-uploader
+  .right-column .file-uploader
     form
       margin-bottom: 5px
       .btn-file
@@ -152,7 +150,7 @@ body#comfy
                 cursor: default
     iframe#file-upload-frame
       display: none
-    
+
   // -- Common Elements -----------------------------------------------------
   table.table, ul.list
     .icon
@@ -186,7 +184,7 @@ body#comfy
   .item-meta
     font-size: 11px
     line-height: 14px
-    
+
   .cms-partial
     background-color: #252525
     color: #fff
@@ -197,14 +195,15 @@ body#comfy
     margin: 3px
     background-image: linear-gradient(-45deg, rgba(255, 255, 255, .05) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .05) 50%, rgba(255, 255, 255, .05) 75%, transparent 75%, transparent)
     background-size: 50px 50px
-  
+
   // -- Sofa Version --------------------------------------------------------
   .center-column .body-footer
-    position: absolute
+    position: fixed
     background: #000
     bottom: 0px
-    left: -175px
-    width: 175px
+    left: 0
+    bottom: 0
+    width: $sidebar-width
     padding: 5px 10px
     font-size: 10px
     a
@@ -215,7 +214,7 @@ body#comfy
     span.version
       color: #f1f1f1
       margin-left: 2px
-      
+
   // -- Categories Widget ---------------------------------------------------
   .categories-widget
     background: #f5f5f5
@@ -259,7 +258,7 @@ body#comfy
           padding: 3px
           font-size: 11px
           line-height: 11px
-          
+
   // -- Sortable List -------------------------------------------------------
   ul.list
     padding: 0
@@ -300,12 +299,12 @@ body#comfy
       list-style: none
       padding: 0
       margin: 0 0 0 28px
-          
+
   // -- Sites ---------------------------------------------------------------
   &.c-comfy-admin-cms-sites
     table .icon
       background: url(image-path("comfortable_mexican_sofa/icon_site.gif"))
-      
+
   // -- Layouts -------------------------------------------------------------
   &.c-comfy-admin-cms-layouts
     ul.list
@@ -314,7 +313,7 @@ body#comfy
           background: url(image-path("comfortable_mexican_sofa/icon_layout.gif"))
         .item-content
           margin-left: 35px
-      
+
   // -- Pages ---------------------------------------------------------------
   &.c-comfy-admin-cms-pages
     #form-blocks
@@ -335,17 +334,17 @@ body#comfy
           padding: 0 5px
           margin-bottom: 5px
           font-size: 12px
-        
+
   // -- Snippets ------------------------------------------------------------
   &.c-comfy-admin-cms-snippets
     table .icon
       background: url(image-path("comfortable_mexican_sofa/icon_snippet.gif"))
-      
+
   // -- Files ---------------------------------------------------------------
   &.c-comfy-admin-cms-files
     table .icon
       background: url(image-path("comfortable_mexican_sofa/icon_file.gif"))
-    
+
   // -- Revisions -----------------------------------------------------------
   &.c-comfy-admin-cms-revisions
     td.with-table

--- a/app/assets/stylesheets/comfortable_mexican_sofa/thin.css.sass
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/thin.css.sass
@@ -1,0 +1,29 @@
+@media (max-width: 768px)
+  body#comfy
+
+    // -- Containers ----------------------------------------------------------
+    .body-wrapper
+      .left-column,
+      .right-column
+        width: 100%
+        position: static
+      .center-column
+        margin: 0
+      .left-column
+        padding: 0
+
+    // -- Navigation ----------------------------------------------------------
+    .left-column ul.navigation
+      text-align: center
+      li
+        display: inline-block
+      a
+        border-bottom: none
+      a.active:after
+        display: none
+
+    // -- Sofa Version --------------------------------------------------------
+    .center-column .body-footer
+      position: absolute
+      width: 100%
+

--- a/app/views/layouts/comfy/admin/cms/_body.html.haml
+++ b/app/views/layouts/comfy/admin/cms/_body.html.haml
@@ -6,12 +6,11 @@
     .left-column
       .left-column-content
         = render :partial => 'layouts/comfy/admin/cms/left'
+    .center-column
+      = render :partial => 'layouts/comfy/admin/cms/center'
+      = render :partial => 'layouts/comfy/admin/cms/footer'
     .right-column
       .right-column-content
         = render :partial => 'layouts/comfy/admin/cms/right'
-    .center-column
-      = render :partial => 'layouts/comfy/admin/cms/center'
-      
-      = render :partial => 'layouts/comfy/admin/cms/footer'
-  
+
   = render :partial => 'layouts/comfy/admin/cms/footer_js'


### PR DESCRIPTION
- Use percentage widths for sidebars to avoid centre column getting super wide
- Reorder columns to put right sidebar content last
- Collapse to single column when viewport gets too thin
- Collapse navigation to inline list at top of page on thin viewports
