### PR TITLE
Update 08_upgrade_to_1_12_0.rb

### DIFF
--- a/db/upgrade_migrations/08_upgrade_to_1_12_0.rb
+++ b/db/upgrade_migrations/08_upgrade_to_1_12_0.rb
@@ -1,4 +1,5 @@
 class UpgradeTo1120 < ActiveRecord::Migration
+  COMFY_CLASSES = %w(Block Category Categorization File Layout Page Revision Site Snippet)
   def self.up
     add_column :cms_blocks, :blockable_type, :string
     add_index :cms_blocks, :blockable_type
@@ -17,9 +18,15 @@ class UpgradeTo1120 < ActiveRecord::Migration
     rename_table :cms_revisions,        :comfy_cms_revisions
     rename_table :cms_categories,       :comfy_cms_categories
     rename_table :cms_categorizations,  :comfy_cms_categorizations
+    COMFY_CLASSES.each {|c| execute("UPDATE comfy_cms_categories      SET categorized_type = 'Comfy::Cms::#{c}' WHERE categorized_type = 'Cms::#{c}'") }
+    COMFY_CLASSES.each {|c| execute("UPDATE comfy_cms_categorizations SET categorized_type = 'Comfy::Cms::#{c}' WHERE categorized_type = 'Cms::#{c}'") }
+    COMFY_CLASSES.each {|c| execute("UPDATE comfy_cms_revisions       SET record_type      = 'Comfy::Cms::#{c}' WHERE record_type      = 'Cms::#{c}'") }
   end
 
   def self.down
+    COMFY_CLASSES.each {|c| execute("UPDATE comfy_cms_revisions       SET record_type      = 'Cms::#{c}'        WHERE record_type      = 'Comfy::Cms::#{c}'") }
+    COMFY_CLASSES.each {|c| execute("UPDATE comfy_cms_categorizations SET categorized_type = 'Cms::#{c}'        WHERE categorized_type = 'Comfy::Cms::#{c}'") }
+    COMFY_CLASSES.each {|c| execute("UPDATE comfy_cms_categories      SET categorized_type = 'Cms::#{c}'        WHERE categorized_type = 'Comfy::Cms::#{c}'") }
     rename_table :comfy_cms_sites,            :cms_sites
     rename_table :comfy_cms_layouts,          :cms_layouts
     rename_table :comfy_cms_pages,            :cms_pages


### PR DESCRIPTION
As Revisions and Categories are polymorphic, we have to change all references to the old class names. Otherwise old entries will loose all categorizations and revisions.
