### PR TITLE
Page API outputs all child blocks

### DIFF
--- a/app/models/comfy/cms/page.rb
+++ b/app/models/comfy/cms/page.rb
@@ -70,6 +70,10 @@ class Comfy::Cms::Page < ActiveRecord::Base
   def url
     "//" + "#{self.site.hostname}/#{self.site.path}/#{self.full_path}".squeeze("/")
   end
+
+  def as_json(options={})
+    super(:include => { :blocks => { :only => [:identifier, :content, :created_at, :updated_at] } })
+  end
   
 protected
   

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -281,7 +281,14 @@ class CmsPageTest < ActiveSupport::TestCase
     assert_equal 0, page_2.children_count
     assert_equal 0, page_3.children_count
   end
-  
+
+  def test_as_json_with_blocks
+    page = comfy_cms_pages(:default)
+
+    assert_equal 'default_field_text', page.as_json['blocks'][0]['identifier']
+    assert_equal 'default_field_text_content', page.as_json['blocks'][0]['content']
+  end
+
 protected
   
   def new_params(options = {})


### PR DESCRIPTION
Previously the API would output the cached content on the Page object. This pull request includes all the blocks on the page so that the receiver can reconstruct as they wish. 

Our use case is several markdown-based blocks which represent different parts of the page, and are converted from markdown in the API consuming app.
