### PR TITLE
Rename test to unique and correct name

### DIFF
--- a/test/lib/fixtures_test.rb
+++ b/test/lib/fixtures_test.rb
@@ -32,7 +32,7 @@ class FixtureTest < ActiveSupport::TestCase
     FileUtils.rm_rf(host_path)
   end
   
-  def test_import_all_with_no_site
+  def test_export_all_with_no_site
     comfy_cms_sites(:default).destroy
     
     assert_exception_raised ActiveRecord::RecordNotFound do


### PR DESCRIPTION
There were 2 test_import_all_with_no_site tests, rename the export test correctly to test_export_all_with_no_site
