### PR TITLE
Relax sass-rails to 4.0.1

### DIFF
--- a/comfortable_mexican_sofa.gemspec
+++ b/comfortable_mexican_sofa.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-rails',      '>= 3.0.0'
   s.add_dependency 'jquery-ui-rails',   '>= 4.0.0'
   s.add_dependency 'haml-rails',        '>= 0.3.0'
-  s.add_dependency 'sass-rails',        '>= 4.0.3'
+  s.add_dependency 'sass-rails',        '>= 4.0.1'
   s.add_dependency 'coffee-rails',      '>= 3.1.0'
   s.add_dependency 'codemirror-rails',  '>= 3.0.0'
   s.add_dependency 'kaminari',          '>= 0.14.0'


### PR DESCRIPTION
4.0.1 is the last version that works with Sass 3.3 on Rails 4. It is also compatible with Comfy.
