### PR TITLE
jquery-ui-rails 5.0: require 'jquery-ui' instead of 'jquery.ui.all'.

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/application.js.coffee
+++ b/app/assets/javascripts/comfortable_mexican_sofa/application.js.coffee
@@ -1,6 +1,6 @@
 #= require jquery
 #= require jquery_ujs
-#= require jquery.ui.all
+#= require jquery-ui
 #= require tinymce-jquery
 #= require codemirror
 #= require codemirror/modes/css

--- a/app/assets/stylesheets/comfortable_mexican_sofa/application.css.sass
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/application.css.sass
@@ -1,4 +1,4 @@
-@import "jquery.ui.all"
+@import "jquery-ui"
 @import "codemirror"
 @import "bootstrap"
 @import "comfortable_mexican_sofa/lib/bootstrap-datetimepicker"

--- a/comfortable_mexican_sofa.gemspec
+++ b/comfortable_mexican_sofa.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'paperclip',         '>= 4.0.0'
   s.add_dependency 'kramdown',          '>= 1.0.0'
   s.add_dependency 'jquery-rails',      '>= 3.0.0'
-  s.add_dependency 'jquery-ui-rails',   '>= 4.0.0'
+  s.add_dependency 'jquery-ui-rails',   '>= 5.0.0'
   s.add_dependency 'haml-rails',        '>= 0.3.0'
   s.add_dependency 'sass-rails',        '>= 4.0.3'
   s.add_dependency 'coffee-rails',      '>= 3.1.0'


### PR DESCRIPTION
When using Rails 4.1(.4), bundle will install jquery-ui-rails 5.0. In this version of jquery-ui-rails, _jquery-ui_ must be required instead of _jquery.ui.all_, both in _application.js_ and _application.css_.

Also changing dependency on _jquery-ui-rails_ to `>= 5.0` - will this break other stuff (i.e. older supported versions of Rails?).
