### PR TITLE
Disable html character encoding

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/application.js.coffee
+++ b/app/assets/javascripts/comfortable_mexican_sofa/application.js.coffee
@@ -59,6 +59,7 @@ window.CMS.wysiwyg = ->
     menubar:        false
     statusbar:      false
     relative_urls:  false
+    entity_encoding : 'raw'
 
 window.CMS.codemirror = ->
   $('textarea[data-cms-cm-mode]').each (i, element) ->


### PR DESCRIPTION
As rails use utf8, there's no need for tinymce to convert characters to.
This makes stored database content cleaner, and it's easier to search the content.
Also, these entities will not display correctly if one tried to strip tags and truncate the content, like so:
truncate(strip_tags(article.content), length: 145, :separator => " ").html_safe

see: http://www.tinymce.com/wiki.php/Configuration:entity_encoding
