### PR TITLE
bootstrap-sprockets is necessary in bootstrap-sass 3.2 gem

### DIFF
--- a/app/assets/stylesheets/comfortable_mexican_sofa/application.css.sass
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/application.css.sass
@@ -1,5 +1,6 @@
 @import "jquery-ui"
 @import "codemirror"
+@import "bootstrap-sprockets"
 @import "bootstrap"
 @import "comfortable_mexican_sofa/lib/bootstrap-datetimepicker"
 @import "comfortable_mexican_sofa/bootstrap_overrides"


### PR DESCRIPTION
The bootstrap-sass Gem requires to import bootstrap-sprockets in application.css.sass. I just noticed it when Bootstrap Glyphicons stopped working. See https://github.com/twbs/bootstrap-sass/issues/653.
