### PR TITLE
imports changed for bootstrap 3.2.0

### DIFF
--- a/app/assets/stylesheets/comfortable_mexican_sofa/application.css.sass
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/application.css.sass
@@ -1,5 +1,6 @@
 @import "jquery-ui"
 @import "codemirror"
+@import "bootstrap-sprockets"
 @import "bootstrap"
 @import "comfortable_mexican_sofa/lib/bootstrap-datetimepicker"
 @import "comfortable_mexican_sofa/bootstrap_overrides"


### PR DESCRIPTION
if we do not include bootstrap-sprockets glyphicons will not be present in comfy!
