### PR TITLE
imports changed for bootstrap 3.2.0

### DIFF
--- a/app/assets/stylesheets/comfortable_mexican_sofa/application.css.sass
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/application.css.sass
@@ -1,5 +1,6 @@
 @import "jquery-ui"
 @import "codemirror"
+@import "bootstrap-sprockets"
 @import "bootstrap"
 @import "comfortable_mexican_sofa/lib/bootstrap-datetimepicker"
 @import "comfortable_mexican_sofa/bootstrap_overrides"

--- a/test/gemfiles/Gemfile.rails.4.0
+++ b/test/gemfiles/Gemfile.rails.4.0
@@ -13,7 +13,7 @@ gem 'coffee-rails',     '>= 3.1.0'
 gem 'codemirror-rails', '>= 3.0.0'
 gem 'kaminari',         '>= 0.14.0'
 gem 'tinymce-rails',    '>= 4.0.0'
-gem 'bootstrap-sass',   '~> 3.1.0'
+gem 'bootstrap-sass',   '~> 3.2.0'
 
 group :test do
   gem 'sqlite3'

--- a/test/gemfiles/Gemfile.rails.4.1
+++ b/test/gemfiles/Gemfile.rails.4.1
@@ -13,7 +13,7 @@ gem 'coffee-rails',     '>= 3.1.0'
 gem 'codemirror-rails', '>= 3.0.0'
 gem 'kaminari',         '>= 0.14.0'
 gem 'tinymce-rails',    '>= 4.0.0'
-gem 'bootstrap-sass',   '~> 3.1.0'
+gem 'bootstrap-sass',   '~> 3.2.0'
 
 group :test do
   gem 'sqlite3'

--- a/test/gemfiles/Gemfile.rails.master
+++ b/test/gemfiles/Gemfile.rails.master
@@ -13,7 +13,7 @@ gem 'coffee-rails',     '>= 3.1.0'
 gem 'codemirror-rails', '>= 3.0.0'
 gem 'kaminari',         '>= 0.14.0'
 gem 'tinymce-rails',    '>= 4.0.0'
-gem 'bootstrap-sass',   '~> 3.1.0'
+gem 'bootstrap-sass',   '~> 3.2.0'
 
 group :test do
   gem 'sqlite3'


### PR DESCRIPTION
if we do not include bootstrap-sprockets glyphicons will not be present in comfy
