### PR TITLE
JSON-API leaks ERB sourcecode

### DIFF
--- a/app/controllers/comfy/cms/content_controller.rb
+++ b/app/controllers/comfy/cms/content_controller.rb
@@ -16,7 +16,7 @@ class Comfy::Cms::ContentController < Comfy::Cms::BaseController
     else
       respond_to do |format|
         format.all { render_page }
-        format.json { render :json => @cms_page }
+        format.json { render :json => @cms_page } unless ComfortableMexicanSofa.config.allow_irb
         format.all { render_page }
       end
     end


### PR DESCRIPTION
I use the erb-templating feature heavily. It allows us to control all the text on all pages and embed functionality where it is required.

If I would allow the json api for these ERB-pages. Any visitor can see the ERB code before it is executed. This code may contain internal comments, model-names, methods or even credentials for external APIs.

Normal Rich-Text only Pages do not have any of these issues. Therefore it is safe to publish them through a JSON-API.

I could live with an enable_json_api option to the config. But I think it would still be a security risk for most users.
