### PR TITLE
Update form_builder.rb

### DIFF
--- a/lib/comfortable_mexican_sofa/form_builder.rb
+++ b/lib/comfortable_mexican_sofa/form_builder.rb
@@ -59,7 +59,7 @@ class ComfortableMexicanSofa::FormBuilder < BootstrapForm::FormBuilder
     content = @template.hidden_field_tag("#{fieldname}[blocks_attributes][#{index}][content]", '', :id => nil)
     content << @template.check_box_tag("#{fieldname}[blocks_attributes][#{index}][content]", '1', tag.content.present?, :id => nil)
     content << @template.hidden_field_tag("#{fieldname}[blocks_attributes][#{index}][identifier]", tag.identifier, :id => nil)
-    form_group :label => {:text => tag.identifier.titleize + "?"} do 
+    form_group :label => {:text => (tag.blockable.class.human_attribute_name(tag.identifier.to_s) || tag.identifier.titleize + "?")} do 
       content
     end
   end


### PR DESCRIPTION
Label for boolean fields are not translated using I18n as other fields
