### PR TITLE
Add configuration for a layout subdirectory

### DIFF
--- a/app/models/comfy/cms/layout.rb
+++ b/app/models/comfy/cms/layout.rb
@@ -46,8 +46,9 @@ class Comfy::Cms::Layout < ActiveRecord::Base
   
   # List of available application layouts
   def self.app_layouts_for_select
-    Dir.glob(File.expand_path('app/views/layouts/**/*.html.*', Rails.root)).collect do |filename|
-      filename.gsub!("#{File.expand_path('app/views/layouts', Rails.root)}/", '')
+    layouts_path = 'app/views/layouts/' + ComfortableMexicanSofa.config.app_layouts_directory
+    Dir.glob(File.expand_path(layouts_path + '**/*.html.*', Rails.root)).collect do |filename|
+      filename.gsub!("#{File.expand_path(layouts_path, Rails.root)}/", '')
       filename.split('/').last[0...1] == '_' ? nil : filename.split('.').first
     end.compact.sort
   end

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -75,6 +75,10 @@ class ComfortableMexicanSofa::Configuration
   # Auto-setting parameter derived from the routes
   attr_accessor :public_cms_path
 
+  # Directory to pull layouts from
+  # Default is ''
+  attr_accessor :app_layouts_directory
+
   # Configuration defaults
   def initialize
     @cms_title            = 'ComfortableMexicanSofa CMS Engine'
@@ -107,14 +111,15 @@ class ComfortableMexicanSofa::Configuration
       'cs'    => 'Česky',
       'nb'    => 'Norsk'
     }
-    @admin_locale         = nil
-    @admin_cache_sweeper  = nil
-    @allow_irb            = false
-    @allowed_helpers      = nil
-    @allowed_partials     = nil
-    @hostname_aliases     = nil
-    @reveal_cms_partials  = false
-    @public_cms_path      = nil
+    @admin_locale          = nil
+    @admin_cache_sweeper   = nil
+    @allow_irb             = false
+    @allowed_helpers       = nil
+    @allowed_partials      = nil
+    @hostname_aliases      = nil
+    @reveal_cms_partials   = false
+    @public_cms_path       = nil
+    @app_layouts_directory = ''
   end
 
 end

--- a/test/models/layout_test.rb
+++ b/test/models/layout_test.rb
@@ -56,7 +56,11 @@ class CmsLayoutTest < ActiveSupport::TestCase
     FileUtils.touch(File.expand_path('app/views/layouts/comfy/not_a_layout.erb', Rails.root))
     
     assert_equal ['comfy/admin/cms', 'comfy/admin/cms/nested'], Comfy::Cms::Layout.app_layouts_for_select
-    
+
+    ComfortableMexicanSofa.config.app_layouts_directory = 'comfy/'
+    assert_equal ['admin/cms', 'admin/cms/nested'], Comfy::Cms::Layout.app_layouts_for_select
+    ComfortableMexicanSofa.config.app_layouts_directory = ''
+
     FileUtils.rm(File.expand_path('app/views/layouts/comfy/admin/cms/nested.html.erb', Rails.root))
     FileUtils.rm(File.expand_path('app/views/layouts/comfy/_partial.html.erb', Rails.root))
     FileUtils.rm(File.expand_path('app/views/layouts/comfy/not_a_layout.erb', Rails.root))


### PR DESCRIPTION
Provide a configuration option so comfy layouts can be kept separate from the rest of the application's layouts.
