### PR TITLE
fix deprecated ujs syntax in link

### DIFF
--- a/app/views/comfy/admin/cms/files/_page_form.html.haml
+++ b/app/views/comfy/admin/cms/files/_page_form.html.haml
@@ -5,5 +5,5 @@
     - files.each do |file|
       .file{:class => dom_id(file)}
         = link_to file.file_file_name, file.file.url, :target => '_blank'
-        = link_to comfy_admin_cms_site_file_path(@site, file), :method => :delete, :remote => true, :confirm => t('.are_you_sure'), :class => 'delete' do
+        = link_to comfy_admin_cms_site_file_path(@site, file), :method => :delete, :remote => true, :data => {:confirm => t('.are_you_sure')}, :class => 'delete' do
           %i.glyphicon.glyphicon-remove-circle


### PR DESCRIPTION
in app/views/comfy/cms/files/_page_form is a link to delete the image. It still used the old syntax for confirm: . This is now changed to the new syntax.