### PR TITLE
Links for Redactor

### DIFF
--- a/app/assets/javascripts/comfy/admin/cms/application.js.coffee
+++ b/app/assets/javascripts/comfy/admin/cms/application.js.coffee
@@ -15,6 +15,7 @@
 #= require comfy/admin/cms/lib/redactor
 #= require comfy/admin/cms/lib/redactor/filemanager
 #= require comfy/admin/cms/lib/redactor/imagemanager
+#= require comfy/admin/cms/lib/redactor/definedlinks
 #= require comfy/admin/cms/lib/redactor/table
 #= require comfy/admin/cms/lib/redactor/video
 #= require_directory ./lib/redactor/i18n/

--- a/app/assets/javascripts/comfy/admin/cms/base.js.coffee
+++ b/app/assets/javascripts/comfy/admin/cms/base.js.coffee
@@ -53,8 +53,9 @@ window.CMS.wysiwyg = ->
     fileManagerJson:  "#{CMS.file_upload_path}?source=redactor&type=file"
     buttonSource:     true
     formattingTags:   ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']
-    plugins:          ['imagemanager', 'filemanager', 'table', 'video']
+    plugins:          ['imagemanager', 'filemanager', 'table', 'video', 'definedlinks']
     lang:             CMS.locale
+    definedLinks: "#{CMS.pages_path}?source=redactor"
 
 
 window.CMS.codemirror = ->

--- a/app/assets/javascripts/comfy/admin/cms/lib/redactor/definedlinks.js
+++ b/app/assets/javascripts/comfy/admin/cms/lib/redactor/definedlinks.js
@@ -1,0 +1,53 @@
+if (!RedactorPlugins) var RedactorPlugins = {};
+
+(function($)
+{
+  RedactorPlugins.definedlinks = function()
+  {
+    return {
+      init: function()
+      {
+        if (!this.opts.definedLinks) return;
+
+        this.modal.addCallback('link', $.proxy(this.definedlinks.load, this));
+
+      },
+      load: function()
+      {
+        var $select = $('<select id="redactor-defined-links" />');
+        $('#redactor-modal-link-insert').prepend($select);
+
+        this.definedlinks.storage = {};
+
+        $.getJSON(this.opts.definedLinks, $.proxy(function(data)
+        {
+          $.each(data, $.proxy(function(key, val)
+          {
+            this.definedlinks.storage[key] = val;
+            $select.append($('<option>').val(key).html(val.name));
+
+          }, this));
+
+          $select.on('change', $.proxy(this.definedlinks.select, this));
+
+        }, this));
+
+      },
+      select: function(e)
+      {
+        var key = $(e.target).val();
+        var name = '', url = '';
+        if (key !== 0)
+        {
+          name = this.definedlinks.storage[key].name;
+          url = this.definedlinks.storage[key].url;
+        }
+
+        $('#redactor-link-url').val(url);
+
+        var $el = $('#redactor-link-url-text');
+        if ($el.val() === '') $el.val(name);
+      }
+    };
+  };
+})(jQuery);

--- a/app/views/layouts/comfy/admin/cms/_head.html.haml
+++ b/app/views/layouts/comfy/admin/cms/_head.html.haml
@@ -9,6 +9,7 @@
   - if @site && @site.persisted?
     :javascript
       CMS.file_upload_path  = '#{comfy_admin_cms_site_files_path(@site)}';
+      CMS.pages_path  = '#{comfy_admin_cms_site_pages_path(@site)}';
       CMS.locale            = '#{I18n.locale}';
 
   = yield :head

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -148,6 +148,7 @@ cs:
             cancel: Zrušit
             update: Upravit stránku
             is_published: Publikovaná
+            choose_link: Select page...
           form_blocks:
             no_tags: |-
               Rozložení nedefinuje žádné obsahové značky.<br/>

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -148,6 +148,7 @@ da:
             cancel: Annuller
             update: Opdater side
             is_published: Udgivet
+            choose_link: Select page...
           form_blocks:
             no_tags: |-
               Layout har ingen indholdtags defineret.<br/>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -148,6 +148,7 @@ de:
             cancel: Abbrechen
             update: Seite speichern
             is_published: Veröffentlicht
+            choose_link: Select page...
           form_blocks:
             no_tags: |-
               Das gewählte Layout hat kein Comfy-Tag deklariert, daher kann diese Seite nicht bearbeitet werden.<br/>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,6 +148,7 @@ en:
             cancel: Cancel
             update: Update Page
             is_published: Published
+            choose_link: Select page...
           form_blocks:
             no_tags: |-
               Layout has no content tags defined.<br/>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -148,6 +148,7 @@ es:
             cancel: Cancelar
             update: Actualizar Página
             is_published: Publicada
+            choose_link: Select page...
           form_blocks:
             no_tags: |-
               La plantilla no tiene etiquetas de contenido definidas.<br/>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -148,6 +148,7 @@ fr:
             cancel: Annuler
             update: Modifier la page
             is_published: Publié
+            choose_link: Select page...
           form_blocks:
             no_tags: |-
               Mise en page sans aucun tag de contenu.<br/>

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -148,6 +148,7 @@ it:
             cancel: Cancellare
             update: Modifica Pagina
             is_published: Pubblicata
+            choose_link: Select page...
           form_blocks:
             no_tags: |-
               Il Layout non ha tag di contenuto definiti.<br/>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -148,6 +148,7 @@ ja:
             cancel: キャンセル
             update: ページを更新
             is_published: パブリッシュ済み
+            choose_link: Select page...
           form_blocks:
             no_tags: |-
               レイアウトにはコンテンツタグが定義されていません。<br/>

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -148,6 +148,7 @@ nb:
             cancel: Cancel
             update: Endre side
             is_published: Publisert
+            choose_link: Velg side...
           form_blocks:
             no_tags: |-
               layout har ingen innholdsknagger definert.<br/>

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -148,6 +148,7 @@ nl:
             cancel: Annuleren
             update: Pagina Bijwerken
             is_published: Gepubliceerd
+            choose_link: Select page...
           form_blocks:
             no_tags: |-
               Lay-out heeft geen inhoud-tags gedefinieerd.<br/>

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -148,6 +148,7 @@ pl:
             cancel: Anulować
             update: Uaktualnij stronę
             is_published: Opublikowana
+            choose_link: Select page...
           form_blocks:
             no_tags: |-
               Szablon nie ma zdefiniowanych tagów<br/>

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -148,6 +148,7 @@ pt-BR:
             cancel: Cancelar
             update: Atualizar Página
             is_published: Publicada
+            choose_link: Select page...
           form_blocks:
             no_tags: |-
               O leiaute não possui tags de conteúdo definidas.<br/>

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -150,6 +150,7 @@ ru:
             cancel: Oтменить
             update: Обновить страницу
             is_published: Опубликована
+            choose_link: Select page...
           form_blocks:
             no_tags: |-
               Шаблон не содержит ни одного контент-тега.<br/>

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -148,6 +148,7 @@ sv:
             cancel: Avbryt
             update: Uppdatera sida
             is_published: Publicerad
+            choose_link: Välj sida...
           form_blocks:
             no_tags: |-
               Layout har inga innehållstaggar definierade.<br/>

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -148,6 +148,7 @@ uk:
             cancel: Cкасувати
             update: Оновити сторінку
             is_published: Опублікована
+            choose_link: Select page...
           form_blocks:
             no_tags: |-
               Шаблон не містить жодного контент-тега. <br/>

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -148,6 +148,7 @@ zh-CN:
             cancel: 取消
             update: 更新页面
             is_published: 发布
+            choose_link: Select page...
           form_blocks:
             no_tags: |-
               布局中没有定义内容标签。<br/>

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -148,6 +148,7 @@ zh-TW:
             cancel: Cancel
             update: 更新頁面
             is_published: 發佈
+            choose_link: Select page...
           form_blocks:
             no_tags: |-
               佈局中沒有定義內容標籤。<br/>

--- a/test/controllers/comfy/admin/cms/pages_controller_test.rb
+++ b/test/controllers/comfy/admin/cms/pages_controller_test.rb
@@ -483,4 +483,16 @@ class Comfy::Admin::Cms::PagesControllerTest < ActionController::TestCase
     assert_equal 0, page_two.position
   end
 
+  def test_get_links_with_redactor
+    page = comfy_cms_pages(:default)
+
+    get :index, :site_id => comfy_cms_sites(:default), :source => 'redactor'
+    assert_response :success
+
+    assert_equal ({
+      'name' => page.label,
+      'url' => page.url(:relative)
+    }), JSON.parse(response.body)[1]
+  end
+
 end

--- a/test/integration/js_variables_test.rb
+++ b/test/integration/js_variables_test.rb
@@ -10,6 +10,7 @@ class JsVariablesIntegrationTest < ActionDispatch::IntegrationTest
     js_vars = <<-HTML.strip_heredoc
       <script>
         CMS.file_upload_path  = '#{comfy_admin_cms_site_files_path(site)}';
+        CMS.pages_path  = '#{comfy_admin_cms_site_pages_path(site)}';
         CMS.locale            = 'en';
       </script>
     HTML


### PR DESCRIPTION
Includes the definedLinks Redactor plugin which does a request to a page which returns a list of defined links. Links are a list of all published pages on the site. The user can then easily make a link from one page to another without knowing the full path to the page.