### PR TITLE
Add live preview to Pages.

### DIFF
--- a/app/assets/javascripts/comfy/admin/cms/base.js.coffee
+++ b/app/assets/javascripts/comfy/admin/cms/base.js.coffee
@@ -16,7 +16,8 @@ window.CMS.init = ->
   CMS.page_blocks()
   CMS.page_file_popovers()
   CMS.mirrors()
-  CMS.page_update_preview()
+  CMS.update_preview()
+  CMS.live_preview()
   CMS.page_update_publish()
   CMS.categories()
   CMS.files()
@@ -119,11 +120,77 @@ window.CMS.mirrors = ->
     window.location = $(this).val()
 
 
-window.CMS.page_update_preview = ->
+window.CMS.update_preview = ->
   $('input[name=commit]').click ->
     $(this).parents('form').attr('target', '')
   $('input[name=preview]').click ->
     $(this).parents('form').attr('target', '_blank')
+
+
+window.CMS.live_preview = ->
+  form = $('form[data-live-preview="true"]')
+  return unless form.length > 0
+
+  # Disable LivePreview on small screens.
+  return if window.screen.width < 1280
+
+  previewWindow = $('iframe#preview')
+  updatePreviewLink = $('a.live-preview-update')
+  updatePreviewLinkText = updatePreviewLink.text()
+
+  # Show the live preview window and controls
+  $('body').addClass "live-preview"
+
+  # We don't need the standard preview link
+  $('input[name=preview]').hide()
+
+  updatePreviewLink.click (e) ->
+    updatePreview()
+    e.preventDefault()
+
+  $('a.live-preview-new-window').click (e) ->
+    submitPreviewForm '_blank'
+    e.preventDefault()
+
+  previewWindow.on 'load', ->
+    # When the preview is updated, scroll back to previous position.
+    $(this).contents().scrollTop($(this).data('scrollPos') || 0)
+    updatePreviewLink.text updatePreviewLinkText
+
+  # Update the preview when the form was changed. Use a timeout to prevent
+  # updates on every keystroke to save CPU.
+  form.bind 'change input', (evt) ->
+    clearTimeout form.data("previewTimeout")
+    form.data 'previewTimeout', setTimeout(->
+      updatePreview()
+    , 1000)
+
+  $(window).on 'resize', ->
+    fitContentAndPreviewHeight()
+
+  updatePreview = ->
+    updatePreviewLink.text updatePreviewLink.data('live-preview-updating')
+
+    # Remember scroll position.
+    previewWindow.data('scrollPos', previewWindow.contents().scrollTop())
+
+    submitPreviewForm()
+
+  submitPreviewForm = (target = 'live-preview') ->
+    # The standard preview works by checking if the preview button was clicked
+    # when the form is submitted. We just fake this by adding a hidden field to the form.
+    form.append($("<input>").attr("type", "hidden").attr("name", "preview").val("1"));
+    form.attr('target', target)
+    form.submit()
+    form.find('input[type=hidden][name=preview]').remove()
+
+  # We have set overflow scrolling on content and preview and set the to the
+  # viewport height so we can scroll content and preview individually.
+  fitContentAndPreviewHeight = ->
+    $('.center-column-content, .center-column-live-preview').css('height', $(window).height());
+
+  fitContentAndPreviewHeight()
+  updatePreview()
 
 
 window.CMS.page_update_publish = ->

--- a/app/assets/stylesheets/comfy/admin/cms/base.sass
+++ b/app/assets/stylesheets/comfy/admin/cms/base.sass
@@ -365,3 +365,56 @@ body#comfy
         background-color: #f5f5f5
       a.active
         border-color: #0088CC
+
+body#comfy
+  .center-column-live-preview
+    display: none
+
+
+// Set iframe > document > html width to simulate devise width
+
+body#comfy.live-preview
+  // Overflow is scrolled on center-column content and preview individually.
+  overflow: hidden
+
+  // No right column if live-preview is on
+  .body-wrapper
+    .center-column
+      margin-right: 0
+
+  .center-column-content
+    width: 50%
+    height: 750px // finally set via JS!
+    overflow-y: scroll
+    overflow-x: hidden
+
+  .center-column-live-preview
+    width: 50%
+    height: 750px // finally set via JS!
+    display: block
+    position: absolute
+    left: 50%
+    top: 0
+    height: 100%
+
+    .live-preview-toolbar
+      position: absolute
+      width: 100%
+      text-align: center
+      opacity: 0
+      transition: opacity 0.1s linear
+      > div
+        display: inline-block
+        margin: 10px 0
+        background: lightgray
+        border-radius: 5px
+        padding: 10px
+
+    &:hover
+      .live-preview-toolbar
+        opacity: 1
+
+    iframe
+      border: none
+      width: 100%
+      height: 100%

--- a/app/assets/stylesheets/comfy/admin/cms/bootstrap_overrides.sass
+++ b/app/assets/stylesheets/comfy/admin/cms/bootstrap_overrides.sass
@@ -2,6 +2,10 @@ body#comfy
   .alert
     text-align: center
     border-radius: 0
+    // Moved the alert from .center-column into .center-column-content to make
+    // it display nicer with the new live-preview. But we need to offset the
+    // margin from .center-column-content to make the alert look like before.
+    margin: -25px -25px 25px -25px
   .page-header
     margin-top: 0
     h2

--- a/app/controllers/comfy/admin/cms/layouts_controller.rb
+++ b/app/controllers/comfy/admin/cms/layouts_controller.rb
@@ -3,6 +3,7 @@ class Comfy::Admin::Cms::LayoutsController < Comfy::Admin::Cms::BaseController
   before_action :build_layout,  :only => [:new, :create]
   before_action :load_layout,   :only => [:edit, :update, :destroy]
   before_action :authorize
+  before_action :preview_layout,  :only => [:create, :update]
 
   def index
     return redirect_to :action => :new if @site.layouts.count == 0
@@ -59,9 +60,30 @@ protected
 
   def load_layout
     @layout = @site.layouts.find(params[:id])
+    @layout.attributes = layout_params
   rescue ActiveRecord::RecordNotFound
     flash[:danger] = I18n.t('comfy.admin.cms.layouts.not_found')
     redirect_to :action => :index
+  end
+
+  def preview_layout
+    if params[:preview]
+      # Build a page we can use to preview the layout.
+      # If pages exists that use the current layout we could let the user
+      # select one of those to preview the layout.
+      @page = @site.pages.new({layout: @layout})
+
+      # Same code as in Comfy::Admin::Cms::PagesController.preview_cms_page. Add concern?
+      layout = @page.layout.app_layout.blank?? false : @page.layout.app_layout
+      @cms_site   = @page.site
+      @cms_layout = @page.layout
+      @cms_page   = @page
+
+      # Chrome chokes on content with iframes. Issue #434
+      response.headers['X-XSS-Protection'] = '0'
+
+      render :inline => @page.render, :layout => layout, :content_type => 'text/html'
+    end
   end
 
   def layout_params

--- a/app/views/comfy/admin/cms/layouts/_form.html.haml
+++ b/app/views/comfy/admin/cms/layouts/_form.html.haml
@@ -15,5 +15,6 @@
 = render 'comfy/admin/cms/partials/layout_form_after', :form => form
 
 = form.form_group :class => 'form-actions' do
+  / = form.submit t('.preview'), :name => 'preview', :id => nil, :class => 'btn btn-default'
   = form.submit t(@layout.new_record?? '.create' : '.update'), :class => 'btn btn-primary'
   = link_to t('.cancel'), comfy_admin_cms_site_layouts_path, :class => 'btn btn-link'

--- a/app/views/comfy/admin/cms/layouts/edit.html.haml
+++ b/app/views/comfy/admin/cms/layouts/edit.html.haml
@@ -5,5 +5,7 @@
 - content_for :right_column do
   = render 'comfy/admin/cms/sites/mirrors', :object => @layout
 
-= comfy_form_for @layout, :as => :layout, :url => {:action => :update} do |form|
+/ Removed live preview from layouts for the moment because it does not preview
+/ js and css because those are always loaded from the database and not the form data.
+= comfy_form_for @layout, :as => :layout, :url => {:action => :update}, :html => {:data => {:live_preview => false}} do |form|
   = render form

--- a/app/views/comfy/admin/cms/layouts/new.html.haml
+++ b/app/views/comfy/admin/cms/layouts/new.html.haml
@@ -1,5 +1,7 @@
 .page-header
   %h2= t('.title')
 
-= comfy_form_for @layout, :as => :layout, :url => {:action => :create} do |form|
+/ Removed live preview from layouts for the moment because it does not preview
+/ js and css because those are always loaded from the database and not the form data.
+= comfy_form_for @layout, :as => :layout, :url => {:action => :create}, :html => {:data => {:live_preview => false}} do |form|
   = render form

--- a/app/views/comfy/admin/cms/pages/edit.html.haml
+++ b/app/views/comfy/admin/cms/pages/edit.html.haml
@@ -5,5 +5,5 @@
 - content_for :right_column do
   = render 'comfy/admin/cms/sites/mirrors', :object => @page
 
-= comfy_form_for @page, :as => :page, :url => {:action => :update}, :html => {:multipart => true} do |form|
+= comfy_form_for @page, :as => :page, :url => {:action => :update}, :html => {:multipart => true, :data => {:live_preview => true}} do |form|
   = render form

--- a/app/views/comfy/admin/cms/pages/new.html.haml
+++ b/app/views/comfy/admin/cms/pages/new.html.haml
@@ -1,5 +1,5 @@
 .page-header
   %h2= t('.title')
 
-= comfy_form_for @page, :as => :page, :url => {:action => :create}, :html => {:multipart => true} do |form|
+= comfy_form_for @page, :as => :page, :url => {:action => :create}, :html => {:multipart => true, :data => {:live_preview => true}} do |form|
   = render form

--- a/app/views/layouts/comfy/admin/cms/_body.html.haml
+++ b/app/views/layouts/comfy/admin/cms/_body.html.haml
@@ -10,9 +10,11 @@
       .right-column-content
         = render 'layouts/comfy/admin/cms/right'
     .center-column
-      = render 'layouts/comfy/admin/cms/flash'
       .center-column-content
+        = render 'layouts/comfy/admin/cms/flash'
         = yield
+      .center-column-live-preview
+        = render 'layouts/comfy/admin/cms/preview'
       = render 'layouts/comfy/admin/cms/footer'
 
   = render 'layouts/comfy/admin/cms/footer_js'

--- a/app/views/layouts/comfy/admin/cms/_left.html.haml
+++ b/app/views/layouts/comfy/admin/cms/_left.html.haml
@@ -9,7 +9,7 @@
     %li= active_link_to t('comfy.admin.cms.base.snippets'), comfy_admin_cms_site_snippets_path(@site)
     %li
       - unless is_active_link?(comfy_admin_cms_site_files_path(@site))
-        %a.cms-files-open-modal{:href => '#', :title => 'Open library'}
+        %a.cms-files-open-modal{:href => '#', :title => t('comfy.admin.cms.files.open_library')}
           %span.glyphicon.glyphicon-th-list
       = active_link_to t('comfy.admin.cms.base.files'), comfy_admin_cms_site_files_path(@site)
 

--- a/app/views/layouts/comfy/admin/cms/_preview.html.haml
+++ b/app/views/layouts/comfy/admin/cms/_preview.html.haml
@@ -1,0 +1,7 @@
+.live-preview-toolbar
+  %div
+    %a.live-preview-update{ href: '#', data: { live_preview_updating: t('comfy.admin.cms.live_preview.refreshing') } }= t('comfy.admin.cms.live_preview.refresh')
+    |
+    %a.live-preview-new-window{ href: '#' }= t('comfy.admin.cms.live_preview.new_window')
+
+%iframe#preview{name: 'live-preview'}

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -39,26 +39,26 @@ cs:
         description: Popis
       comfy/cms/snippet:
         identifier: Identifikátor
-        
+
   comfy:
     cms:
       content:
         site_not_found: Web nenalezen
         layout_not_found: Rozložení nenalezeno
         page_not_found: Stránka nenalezena
-    
+
     admin:
       cms:
         base:
           site_not_found: Web nenalezen
           fixtures_enabled: Je povolen pevně definovaný obsah CMS. Všechny zde provedené změny budou ztraceny.
-          
+
           sites: Weby
           layouts: Rozložení
           pages: Stránky
           snippets: Úryvky
           files: Soubory
-  
+
         sites:
           created: Web vytvořen
           creation_failure: Nepodařilo se vytvořit web
@@ -66,7 +66,7 @@ cs:
           update_failure: Nepodařilo se upravit web
           deleted: Web odstraněn
           not_found: Web nenalezen
-          
+
           index:
             title: Weby
             new_link: Vytvořit web
@@ -83,7 +83,7 @@ cs:
             cancel: Zrušit
             update: Upravit web
             is_mirrored: Zrcadlený
-  
+
         layouts:
           created: Rozložení vytvořeno
           creation_failure: Nepodařilo se vytvořit rozložení
@@ -91,7 +91,7 @@ cs:
           update_failure: Nepodařilo se upravit rozložení
           deleted: Rozložení odstraněno
           not_found: Rozložení nenalezeno
-          
+
           index:
             title: Rozložení
             new_link: Vytvořit nové rozložení
@@ -116,7 +116,7 @@ cs:
             create: Vytvořit rozložení
             cancel: Zrušit
             update: Upravit rozložení
-  
+
         pages:
           created: Stránka vytvořena
           creation_failure: Nepodařilo se vytvořit stránku
@@ -125,7 +125,7 @@ cs:
           deleted: Stránka odstraněna
           not_found: Stránka nenalezena
           layout_not_found: "Nebyla nalezena žádná rozložení, vytvořte je prosím."
-          
+
           index:
             title: Stránky
             new_link: Vytvořit novou stránku
@@ -153,7 +153,7 @@ cs:
             no_tags: |-
               Rozložení nedefinuje žádné obsahové značky.<br/>
               Upravte jeho obsah tak, aby zahrnovalo obsahové značky. Například: <code>{{cms:page:content}}</code>
-  
+
         snippets:
           created: Úryvek vytvořen
           creation_failure: Nepodařilo se vytvořit úryvek
@@ -161,7 +161,7 @@ cs:
           update_failure: Nepodařilo se upravit úryvek
           deleted: Úryvek odstraněn
           not_found: Úryvek nenalezen
-          
+
           index:
             title: Úryvky
             new_link: Vytvořit úryvek
@@ -178,12 +178,12 @@ cs:
             create: Vytvořit úryvek
             cancel: Zrušit
             update: Upravit úryvek
-  
+
         revisions:
           reverted: Obsah byl obnoven
           record_not_found: Záznam nenalezen
           not_found: Revize nenalezena
-          
+
           show:
             title: Revize pro
             revision: Revize
@@ -194,7 +194,7 @@ cs:
             changes: Změny
             previous: Předchozí
             current: Aktuální
-  
+
         files:
           created: Soubory nahrány
           creation_failure: Nepodařilo se nahrát soubory
@@ -202,7 +202,8 @@ cs:
           update_failure: Nepodařilo se upravit soubor
           deleted: Soubor odstraněn
           not_found: Soubor nenalezen
-          
+          open_library: Open files library
+
           index:
             title: Soubory
             new_link: Nahrát nový soubor
@@ -223,7 +224,7 @@ cs:
             are_you_sure: Určitě?
           file:
             are_you_sure: Určitě?
-        
+
         categories:
           index:
             label: Kategorie
@@ -238,3 +239,8 @@ cs:
             save: Uložit
           form:
             label: Kategorie
+
+        live_preview:
+          refresh: Refresh
+          refreshing: Refreshing
+          new_window: New Window

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -46,19 +46,19 @@ da:
         site_not_found: Websted findes ikke
         layout_not_found: Layout findes ikke
         page_not_found: Side findes ikke
-        
+
     admin:
         cms:
           base:
             site_not_found: Webstedet findes ikke
             fixtures_enabled: CMS Fixtures er slået til. Alle ændringer til blive ignoreret.
-            
+
             sites: Websteder
             layouts: Layouts
             pages: Sider
             snippets: Snippets
             files: Filer
-    
+
         sites:
           created: Websted oprettet
           creation_failure: Oprettelse af websted mislykkedes
@@ -66,7 +66,7 @@ da:
           update_failure: Opdatering af websted mislykkedes
           deleted: Websted slettet
           not_found: Websted findes ikke
-          
+
           index:
             title: Websteder
             new_link: Opret nyt websted
@@ -83,7 +83,7 @@ da:
             cancel: Annuller
             update: Opdater websted
             is_mirrored: Kopieret websted
-    
+
         layouts:
           created: Layout oprettet
           creation_failure: Oprettelse af layout mislykkedes
@@ -91,7 +91,7 @@ da:
           update_failure: Opdatering af layout mislykkedes
           deleted: Layout slettet
           not_found: Layout findes ikke
-          
+
           index:
             title: Layouts
             new_link: Opret nyt layout
@@ -116,7 +116,7 @@ da:
             create: Opret layout
             cancel: Annuller
             update: Opdater layout
-    
+
         pages:
           created: Side oprettet
           creation_failure: Oprettelse af side mislykkedes
@@ -125,7 +125,7 @@ da:
           deleted: Side slettet
           not_found: Side findes ikke
           layout_not_found: Ingen layouts findes. Opret venligst et layout.
-          
+
           index:
             title: Sider
             new_link: Opret ny side
@@ -153,7 +153,7 @@ da:
             no_tags: |-
               Layout har ingen indholdtags defineret.<br/>
               Rediger indholdet for at inkluderere et side- eller felttag. Eksempelvis: <code>{{cms:page:content}}</code>
-    
+
         snippets:
           created: Snippet oprettet
           creation_failure: Oprettelse af snippet mislykkedes
@@ -161,7 +161,7 @@ da:
           update_failure: Opdatering af snippet mislykkedes
           deleted: Snippet slettet
           not_found: Snippet findes ikke
-          
+
           index:
             title: Snippets
             new_link: Opret ny snippet
@@ -178,12 +178,12 @@ da:
             create: Opret snippet
             cancel: Annuller
             update: Opdater snippet
-    
+
         revisions:
           reverted: Indhold gendannet
           record_not_found: Indhold findes ikke
           not_found: Revision findes ikke
-          
+
           show:
             title: Revisioner for
             revision: Revision
@@ -194,7 +194,7 @@ da:
             changes: Ændringer
             previous: Forrige
             current: Nuværende
-    
+
         files:
           created: Filer sendt
           creation_failure: Sending af filer mislykkedes
@@ -202,7 +202,8 @@ da:
           update_failure: Opdatering af fil mislykkedes
           deleted: Fil slettet
           not_found: Fil findes ikke
-          
+          open_library: Open files library
+
           index:
             title: Filer
             new_link: Send ny fil
@@ -223,7 +224,7 @@ da:
             are_you_sure: Er du sikker?
           file:
             are_you_sure: Er du sikker?
-            
+
         categories:
           index:
             label: Kategorier
@@ -238,3 +239,8 @@ da:
             save: Gem
           form:
             label: Kategorier
+
+        live_preview:
+          refresh: Refresh
+          refreshing: Refreshing
+          new_window: New Window

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -202,6 +202,7 @@ de:
           update_failure: Fehler beim Aktualisieren der Datei!
           deleted: Datei gelöscht
           not_found: Datei nicht gefunden
+          open_library: Bibliothek öffnen
 
           index:
             title: Datei
@@ -238,3 +239,8 @@ de:
             save: Kategorie speichern
           form:
             label: Kategorien
+
+        live_preview:
+          refresh: Aktualisieren
+          refreshing: Aktualisiere
+          new_window: Neues Fenster

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,6 +116,7 @@ en:
             create: Create Layout
             cancel: Cancel
             update: Update Layout
+            preview: Preview
 
         pages:
           created: Page created
@@ -202,6 +203,7 @@ en:
           update_failure: Failed to update file
           deleted: File deleted
           not_found: File not found
+          open_library: Open files library
 
           index:
             title: Files
@@ -240,3 +242,8 @@ en:
             save: Save
           form:
             label: Categories
+
+        live_preview:
+          refresh: Refresh
+          refreshing: Refreshing
+          new_window: New Window

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -46,13 +46,13 @@ es:
         site_not_found: Sitio no encontrado
         layout_not_found: Diseño no encontrado
         page_not_found: Página no encontrada
-        
+
     admin:
       cms:
         base:
           site_not_found: Sitio no encontrado
           fixtures_enabled: CMS Fixtures habilitadas. Todos los cambios realizados serán descartados.
-          
+
           sites: Sitios
           layouts: Diseños
           pages: Páginas
@@ -66,7 +66,7 @@ es:
           update_failure: El sitio no ha podido ser actualizado
           deleted: Sitio eliminado
           not_found: Sitio no encontrado
-          
+
           index:
             title: Listado de Sitios
             new_link: Crear nuevo Sitio
@@ -91,7 +91,7 @@ es:
           update_failure: El diseño NO ha podido ser Actualizado
           deleted: Diseñó Eliminado
           not_found: Diseño no encontrado
-          
+
           index:
             title: Diseños
             new_link: Crear Nuevo Diseño
@@ -125,7 +125,7 @@ es:
           deleted: Página eliminada
           not_found: Página no encontrada
           layout_not_found: No se ha encontrado una plantilla. Cree una primero.
-          
+
           index:
             title: Páginas
             new_link: Crear Nueva Página
@@ -161,7 +161,7 @@ es:
           update_failure: El fragmento no ha podido ser actualizado
           deleted: Fragmento eliminado
           not_found: Fragmento no encontrado
-          
+
           index:
             title: Fragmentos
             new_link: Crear nuevo Fragmento
@@ -183,7 +183,7 @@ es:
           reverted: Contenido revertido
           record_not_found: Registro no encontrado
           not_found: Revisión no encontrada
-          
+
           show:
             title: Revisiones de
             revision: Revisión
@@ -202,7 +202,8 @@ es:
           update_failure: Fallo la actualización del archivo
           deleted: Archivo borrado
           not_found: Archivo no encontrado
-          
+          open_library: Open files library
+
           index:
             title: Archivos
             new_link: Subir Nuevo Archivo
@@ -223,7 +224,7 @@ es:
             are_you_sure: ¿Estás seguro?
           file:
             are_you_sure: ¿Estás seguro?
-            
+
         categories:
           index:
             label: Categorias
@@ -238,3 +239,8 @@ es:
             save: Guardar
           form:
             label: Categorias
+
+        live_preview:
+          refresh: Refresh
+          refreshing: Refreshing
+          new_window: New Window

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -39,20 +39,20 @@ fr:
         description: Description
       comfy/cms/snippet:
         identifier: Identifiant
-        
+
   comfy:
     cms:
       content:
         site_not_found: Site introuvable
         layout_not_found: Mise en page introuvable
         page_not_found: Page introuvable
-        
+
     admin:
       cms:
         base:
           site_not_found: Site introuvable
           fixtures_enabled: Fixtures activés. Toutes les modifications seront supprimées.
-          
+
           sites: Sites
           layouts: Mises en page
           pages: Pages
@@ -66,7 +66,7 @@ fr:
           update_failure: Échec de la modification du site
           deleted: Site supprimé
           not_found: Site introuvable
-          
+
           index:
             title: Sites
             new_link: Nouveau site
@@ -83,7 +83,7 @@ fr:
             cancel: Annuler
             update: Modifier le site
             is_mirrored: En miroir
-      
+
         layouts:
           created: Mise en page créée
           creation_failure: Échec de la création de la mise en page
@@ -91,7 +91,7 @@ fr:
           update_failure: Échec de la modification de la mise en page
           deleted: Mise en page supprimée
           not_found: Mise en page introuvable
-          
+
           index:
             title: Mises en page
             new_link: Nouvelle mise en page
@@ -116,7 +116,7 @@ fr:
             create: Créer la mise en page
             cancel: Annuler
             update: Modifier la mise en page
-      
+
         pages:
           created: Page créée
           creation_failure: Échec de la création de la page
@@ -125,7 +125,7 @@ fr:
           deleted: Page supprimée
           not_found: Page introuvable
           layout_not_found: Aucune mise en page disponible. Créez-en une nouvelle.
-          
+
           index:
             title: Pages
             new_link: Nouvelle page
@@ -153,7 +153,7 @@ fr:
             no_tags: |-
               Mise en page sans aucun tag de contenu.<br/>
               Modifiez le contenu pour y ajouter un tag de page ou de champ. Exemple : <code>{{cms:page:content}}</code>
-      
+
         snippets:
           created: Fragment créé
           creation_failure: Échec de la création du fragment
@@ -161,7 +161,7 @@ fr:
           update_failure: Échec de la modification du fragment
           deleted: Fragment supprimé
           not_found: Fragment introuvable
-          
+
           index:
             title: Fragments
             new_link: Nouveau fragment
@@ -178,23 +178,23 @@ fr:
             create: Créer le fragment
             cancel: Annuler
             update: Modifier le fragment
-      
+
         revisions:
           reverted: Contenu restauré
           record_not_found: Enregistrement introuvable
           not_found: Révision introuvable
-          
+
           show:
             title: "Révisions :"
             revision: révision
-            full_path: Chemin complet 
+            full_path: Chemin complet
             slug: Identifiant
             update: Restaurer cette révision
             content: Content
             changes: Changes
             previous: Previous
             current: Actuel
-      
+
         files:
           created: Fichier téléchargé
           creation_failure: Échec du téléchargement du fichier
@@ -202,7 +202,8 @@ fr:
           update_failure: Échec de la modification du fichier
           deleted: Fichier supprimé
           not_found: Fichier introuvable
-          
+          open_library: Open files library
+
           index:
             title: Fichiers
             new_link: Nouveau fichier
@@ -223,7 +224,7 @@ fr:
             are_you_sure: Êtes-vous sûr de vouloir supprimer ce fichier ?
           file:
             are_you_sure: Êtes-vous sûr de vouloir supprimer ce fichier ?
-            
+
         categories:
           index:
             label: Catégories
@@ -238,3 +239,8 @@ fr:
             save: Enregistrer
           form:
             label: Catégories
+
+        live_preview:
+          refresh: Refresh
+          refreshing: Refreshing
+          new_window: New Window

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -202,6 +202,7 @@ it:
           update_failure: Impossibile aggiornare il file
           deleted: File eliminato
           not_found: File non trovato
+          open_library: Open files library
 
           index:
             title: Files
@@ -238,3 +239,8 @@ it:
             save: Salva
           form:
             label: Categorie
+
+        live_preview:
+          refresh: Refresh
+          refreshing: Refreshing
+          new_window: New Window

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -39,26 +39,26 @@ ja:
         description: Description
       comfy/cms/snippet:
         identifier: Identifier
-        
+
   comfy:
     cms:
       content:
         site_not_found: サイトが見つかりません
         layout_not_found: レイアウトが見つかりません
         page_not_found: ページが見つかりません
-        
+
     admin:
       cms:
         base:
           site_not_found: サイトが見つかりません
           fixtures_enabled: CMS フィクスチャが有効です。 ここでの変更はすべて破棄されます。
-          
+
           sites: サイト
           layouts: レイアウト
           pages: ページ
           snippets: スニペット
           files: ファイル
-      
+
         sites:
           created: サイトが作成されました
           creation_failure: サイトの作成に失敗しました
@@ -66,7 +66,7 @@ ja:
           update_failure: サイトの更新に失敗しました
           deleted: サイトが削除されました
           not_found: サイトが見つかりません
-          
+
           index:
             title: サイト
             new_link: 新規サイトを作成
@@ -83,7 +83,7 @@ ja:
             cancel: キャンセル
             update: サイトを更新
             is_mirrored: ミラーリング済み
-      
+
         layouts:
           created: レイアウトが作成されました
           creation_failure: レイアウトの作成に失敗しました
@@ -91,7 +91,7 @@ ja:
           update_failure: レイアウトの更新に失敗しました
           deleted: レイアウトが削除されました
           not_found: レイアウトが見つかりません
-          
+
           index:
             title: レイアウト
             new_link: 新規レイアウトを作成
@@ -116,7 +116,7 @@ ja:
             create: レイアウトを作成
             cancel: キャンセル
             update: レイアウトを更新
-      
+
         pages:
           created: ページが作成されました
           creation_failure: ページの作成に失敗しました
@@ -125,7 +125,7 @@ ja:
           deleted: ページが削除されました
           not_found: ページが見つかりません
           layout_not_found: レイアウトが見つかりません。 レイアウトを作成してください。
-          
+
           index:
             title: ページ
             new_link: 新規ページを作成
@@ -153,7 +153,7 @@ ja:
             no_tags: |-
               レイアウトにはコンテンツタグが定義されていません。<br/>
               コンテンツを編集してページまたはフィールドタグを含めてください。 例:  <code>{{cms:page:content}}</code>
-      
+
         snippets:
           created: スニペットが作成されました
           creation_failure: スニペットの作成に失敗しました
@@ -161,7 +161,7 @@ ja:
           update_failure: スニペットの更新に失敗しました
           deleted: スニペットが削除されました
           not_found: スニペットが見つかりません
-          
+
           index:
             title: スニペット
             new_link: 新規スニペットを作成
@@ -178,12 +178,12 @@ ja:
             create: スニペットを作成
             cancel: キャンセル
             update: スニペットを更新
-      
+
         revisions:
           reverted: コンテンツが元に戻りました
           record_not_found: レコードが見つかりません
           not_found: リビジョンが見つかりません
-          
+
           show:
             title: リビジョン
             revision: リビジョン
@@ -194,7 +194,7 @@ ja:
             changes: Changes
             previous: Previous
             current: Current
-      
+
         files:
           created: ファイルがアップロードされました
           creation_failure: ファイルのアップロードに失敗しました
@@ -202,7 +202,8 @@ ja:
           update_failure: ファイルの更新に失敗しました
           deleted: ファイルが削除されました
           not_found: ファイルが見つかりません
-          
+          open_library: Open files library
+
           index:
             title: ファイル
             new_link: 新規ファイルをアップロード
@@ -223,7 +224,7 @@ ja:
             are_you_sure: よろしいですか？
           file:
             are_you_sure: よろしいですか？
-            
+
         categories:
           index:
             label: カテゴリー
@@ -238,3 +239,8 @@ ja:
             save: 保存
           form:
             label: カテゴリー
+
+        live_preview:
+          refresh: Refresh
+          refreshing: Refreshing
+          new_window: New Window

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -202,6 +202,7 @@ nb:
           update_failure: Klarte ikke å endre fil
           deleted: Fil fjernet
           not_found: File not found
+          open_library: Open files library
 
           index:
             title: Filer
@@ -238,3 +239,8 @@ nb:
             save: Lagre
           form:
             label: Kategorier
+
+        live_preview:
+          refresh: Refresh
+          refreshing: Refreshing
+          new_window: New Window

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -46,13 +46,13 @@ nl:
         site_not_found: Site niet gevonden
         layout_not_found: Lay-out niet gevonden
         page_not_found: Pagina niet gevonden
-        
+
     admin:
       cms:
         base:
           site_not_found: Site niet gevonden
           fixtures_enabled: CMS Fixtures zijn ingeschakeld. Alle veranderingen die hier gedaan zijn worden weggegooid.
-          
+
           sites: Sites
           layouts: Lay-outs
           pages: Pagina's
@@ -66,7 +66,7 @@ nl:
           update_failure: Site bijwerken mislukt
           deleted: Site verwijderd
           not_found: Site niet gevonden
-          
+
           index:
             title: Sites
             new_link: Maak Nieuwe Site Aan
@@ -91,7 +91,7 @@ nl:
           update_failure: Lay-out bijwerken mislukt
           deleted: Lay-out verwijderd
           not_found: Lay-out niet gevonden
-          
+
           index:
             title: Lay-outs
             new_link: Maak Nieuwe Lay-out Aan
@@ -125,7 +125,7 @@ nl:
           deleted: Pagina verwijderd
           not_found: Pagina niet gevonden
           layout_not_found: Geen Lay-outs gevonden. Maak er a.u.b. een aan.
-          
+
           index:
             title: Pagina's
             new_link: Maak Nieuwe Pagina Aan
@@ -161,7 +161,7 @@ nl:
           update_failure: Snippet bijwerken mislukt
           deleted: Snippet verwijderd
           not_found: Snippet niet gevonden
-          
+
           index:
             title: Snippets
             new_link: Maak Nieuw Snippet Aan
@@ -183,7 +183,7 @@ nl:
           reverted: Content teruggezet
           record_not_found: Record niet gevonden
           not_found: Revisie niet gevonden
-          
+
           show:
             title: Revisies van
             revision: Revisie
@@ -202,7 +202,8 @@ nl:
           update_failure: Bestand bijwerken mislukt
           deleted: Bestand verwijderd
           not_found: Bestand niet gevonden
-          
+          open_library: Open files library
+
           index:
             title: Bestanden
             new_link: Upload Nieuw Bestand
@@ -223,7 +224,7 @@ nl:
             are_you_sure: Weet u het zeker?
           file:
             are_you_sure: Weet u het zeker?
-            
+
         categories:
           index:
             label: Categorieën
@@ -238,3 +239,8 @@ nl:
             save: Opslaan
           form:
             label: Categorieën
+
+        live_preview:
+          refresh: Refresh
+          refreshing: Refreshing
+          new_window: New Window

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -46,19 +46,19 @@ pl:
         site_not_found: Witryna nie została znaleziona
         layout_not_found: Szablon nie został znaleziony
         page_not_found: Strona nie została znaleziona
-      
+
     admin:
       cms:
         base:
           site_not_found: Strona nie została znaleziona
           fixtures_enabled: Fikstury CMS są włączone. Wszystkie zmiany zpisane tutaj nie będą uwzględnione.
-          
+
           sites: Witryny
           layouts: Szablony
           pages: Pages
           snippets: Snippets
           files: Files
-      
+
         sites:
           created: Witryna została utworzona
           creation_failure: Błąd przy tworzeniu witryny
@@ -66,7 +66,7 @@ pl:
           update_failure: Błąd przy uaktualnianiu witryny
           deleted: Witryna została usunięta
           not_found: Nie znaleziono witryny
-          
+
           index:
             title: Witryny
             new_link: Utwórz nowa witrynę
@@ -83,7 +83,7 @@ pl:
             cancel: Anulować
             update: Uaktualnij witrynę
             is_mirrored: Mirror
-      
+
         layouts:
           created: Szablon został utworzony
           creation_failure: Błąd przy tworzeniu layoutu
@@ -91,7 +91,7 @@ pl:
           update_failure: Błąd przy uaktualnianiu layoutu
           deleted: Szablon został usunięty
           not_found: Nie znaleziono layoutu
-          
+
           index:
             title: Szablony
             new_link: Utwórz nowy szablon
@@ -116,7 +116,7 @@ pl:
             create: Stwórz szablon
             cancel: Anulować
             update: Uaktualnij szablon
-      
+
         pages:
           created: Strona została utworzona
           creation_failure: Błąd przy tworzeniu strony
@@ -125,7 +125,7 @@ pl:
           deleted: Strona została usunięta
           not_found: Nie znaleziono strony
           layout_not_found: Brakuje layoutu. Proszę utworzyć
-          
+
           index:
             title: Strony
             new_link: Utwórz nową stronę
@@ -153,7 +153,7 @@ pl:
             no_tags: |-
               Szablon nie ma zdefiniowanych tagów<br/>
               Wyedytuj treść aby dodać stronę lub pole np. <code>{{cms:page:content}}</code>
-      
+
         snippets:
           created: Snippet został utworzony
           creation_failure: Błąd przy tworzeniu snippeta
@@ -161,7 +161,7 @@ pl:
           update_failure: Błąd przy uaktualnianiu snippeta
           deleted: Snippet został usunięty
           not_found: Nie znaleziono snippeta
-          
+
           index:
             title: Snippets
             new_link: Utwórz nowy snippet
@@ -178,12 +178,12 @@ pl:
             create: Utwórz snippet
             cancel: Anulować
             update: Uaktualnij snippet
-      
+
         revisions:
           reverted: Zawartość zostala przywrócona
           record_not_found: Wpis nie został znaleziony
           not_found: Wersja nie została znaleziona
-          
+
           show:
             title: Wersje dla
             revision: Wersja
@@ -194,7 +194,7 @@ pl:
             changes: Changes
             previous: Previous
             current: Aktualna
-      
+
         files:
           created: Plik wrzucony na serwer
           creation_failure: Błąd przy wrzucaniu pliku
@@ -202,7 +202,8 @@ pl:
           update_failure: Błąd przy uaktualnianiu pliku
           deleted: Plik został usunięty
           not_found: Plik nie został znaleziony
-          
+          open_library: Open files library
+
           index:
             title: Pliki
             new_link: Wrzuć nowy plik
@@ -223,7 +224,7 @@ pl:
             are_you_sure: Jesteś pewien?
           file:
             are_you_sure: Jesteś pewien?
-            
+
         categories:
           index:
             label: Kategorie
@@ -238,3 +239,8 @@ pl:
             save: Zapisz
           form:
             label: Tytuł
+
+        live_preview:
+          refresh: Refresh
+          refreshing: Refreshing
+          new_window: New Window

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -39,26 +39,26 @@ pt-BR:
         description: Descrição
       comfy/cms/snippet:
         identifier: Identificador
-        
+
   comfy:
     cms:
       content:
         site_not_found: Site Não Encontrado
         layout_not_found: Leiaute Não Encontrado
         page_not_found: Página Não Encontrada
-        
+
     admin:
       cms:
         base:
           site_not_found: Site não encontrado
           fixtures_enabled: Os Fixtures do CMS estão ativados. Todas as mudanças feitas aqui serão descartadas.
-          
+
           sites: Sites
           layouts: Leiautes
           pages: Páginas
           snippets: Fragmentos
           files: Arquivos
-      
+
         sites:
           created: Site criado com sucesso.
           creation_failure: Não foi possível criar site.
@@ -66,7 +66,7 @@ pt-BR:
           update_failure: Não foi possível atualizar site.
           deleted: Site excluído com sucesso.
           not_found: Site não encontrado.
-          
+
           index:
             title: Sites
             new_link: Criar Novo Site
@@ -83,7 +83,7 @@ pt-BR:
             cancel: Cancelar
             update: Atualizar Site
             is_mirrored: Espelhado
-      
+
         layouts:
           created: Leiaute criado com sucesso.
           creation_failure: Não foi possível criar leiaute.
@@ -91,7 +91,7 @@ pt-BR:
           update_failure: Não foi possível atualizar leiaute.
           deleted: Leiaute excluído com sucesso.
           not_found: Leiaute não encontrado.
-          
+
           index:
             title: Leiautes
             new_link: Criar Novo Leiaute
@@ -116,7 +116,7 @@ pt-BR:
             create: Criar Leiaute
             cancel: Cancelar
             update: Atualizar Leiaute
-      
+
         pages:
           created: Página criada com sucesso.
           creation_failure: Não foi possível criar página.
@@ -125,7 +125,7 @@ pt-BR:
           deleted: Página excluída com sucesso.
           not_found: Página não encontrada.
           layout_not_found: "Nenhum leiaute foi encontrado. Por favor, crie um."
-          
+
           index:
             title: Páginas
             new_link: Criar Nova Página
@@ -153,7 +153,7 @@ pt-BR:
             no_tags: |-
               O leiaute não possui tags de conteúdo definidas.<br/>
               Edite o conteúdo e inclua uma tag de página ou de campo. Por exemplo: <code>{{cms:page:content}}</code>
-      
+
         snippets:
           created: Fragmento criado com sucesso.
           creation_failure: Não foi possível criar fragmento.
@@ -161,7 +161,7 @@ pt-BR:
           update_failure: Não foi possível atualizar fragmento.
           deleted: Fragmento excluído com sucesso.
           not_found: Fragmento não encontrado.
-          
+
           index:
             title: Fragmentos
             new_link: Criar Novo Fragmento
@@ -183,7 +183,7 @@ pt-BR:
           reverted: Conteúdo revertido com sucesso.
           record_not_found: Registro não encontrado.
           not_found: Revisão não encontrada.
-          
+
           show:
             title: Revisões de
             revision: Revisão
@@ -194,7 +194,7 @@ pt-BR:
             changes: Changes
             previous: Previous
             current: Atual
-      
+
         files:
           created: Arquivo enviado com sucesso.
           creation_failure: Não foi possível enviar arquivo.
@@ -202,7 +202,8 @@ pt-BR:
           update_failure: Não foi possível atualizar arquivo.
           deleted: Arquivo excluído com sucesso.
           not_found: Arquivo não encontrado.
-          
+          open_library: Open files library
+
           index:
             title: Arquivos
             new_link: Enviar Novo Arquivo
@@ -223,7 +224,7 @@ pt-BR:
             are_you_sure: Tem certeza?
           file:
             are_you_sure: Tem certeza?
-            
+
         categories:
           index:
             label: Categorias
@@ -238,3 +239,8 @@ pt-BR:
             save: Salvar
           form:
             label: Categorias
+
+        live_preview:
+          refresh: Refresh
+          refreshing: Refreshing
+          new_window: New Window

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -48,13 +48,13 @@ ru:
         site_not_found: Сайт не найден
         layout_not_found: Шаблон не найден
         page_not_found: Страница не найдена
-      
+
     admin:
       cms:
         base:
           site_not_found: Сайт не найден
           fixtures_enabled: CMS Fixtures включены. Все изменения, сделанные здесь, будут отменены.
-          
+
           sites: Сайты
           layouts: Шаблоны
           pages: Страницы
@@ -68,7 +68,7 @@ ru:
           update_failure: Не удалось обновить сайт
           deleted: Сайт удален
           not_found: Сайт не найден
-          
+
           index:
             title: Сайты
             new_link: Создать новый сайт
@@ -93,7 +93,7 @@ ru:
           update_failure: Не удалось обновить шаблон
           deleted: Шаблон удален
           not_found: Шаблон не найден
-          
+
           index:
             title: Шаблоны
             new_link: Создать новый шаблон
@@ -127,7 +127,7 @@ ru:
           deleted: Страница удалена
           not_found: Страница не найдена
           layout_not_found: Шаблоны не найдены. Пожалуйста, создайте хотя бы один шаблон.
-          
+
           index:
             title: Страницы
             new_link: Создать новую страницу
@@ -163,7 +163,7 @@ ru:
           update_failure: Не удалось обновить сниппет
           deleted: Сниппет удален
           not_found: Сниппет не найден
-          
+
           index:
             title: Сниппеты
             new_link: Создать новый сниппет
@@ -185,7 +185,7 @@ ru:
           reverted: Контент возвращен в прежнее состояние
           record_not_found: Запись не найдена
           not_found: Ревизия не найдена
-          
+
           show:
             title: Ревизии для
             revision: Ревизия
@@ -204,7 +204,8 @@ ru:
           update_failure: Не удалось обновить файл
           deleted: Файл удален
           not_found: Файл не найден
-          
+          open_library: Open files library
+
           index:
             title: Файлы
             new_link: Загрузить новый файл
@@ -225,7 +226,7 @@ ru:
             are_you_sure: Вы уверены?
           file:
             are_you_sure: Вы уверены?
-            
+
         categories:
           index:
             label: Категории
@@ -240,3 +241,8 @@ ru:
             save: Сохранить
           form:
             label: Категории
+
+        live_preview:
+          refresh: Refresh
+          refreshing: Refreshing
+          new_window: New Window

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -39,26 +39,26 @@ sv:
         description: Beskrivninig
       comfy/cms/snippet:
         identifier: Identifierare
-        
+
   comfy:
     cms:
       content:
         site_not_found: Kunde inte hitta site
         layout_not_found: Kunde inte hitta layout
         page_not_found: Kunde inte hitta sida
-      
+
     admin:
       cms:
         base:
           site_not_found: Site kan inte hittas
           fixtures_enabled: CMS Fixtures är aktiverade. Inga ändringar kommer att sparas.
-          
+
           sites: Sites
           layouts: Layouter
           pages: Sidor
           snippets: Snippets
           files: Filer
-      
+
         sites:
           created: Site skapad
           creation_failure: Kunde inte skapa site
@@ -66,7 +66,7 @@ sv:
           update_failure: Uppdatering av site misslyckades
           deleted: Site borttagen
           not_found: Kunde inte hitta site
-          
+
           index:
             title: Siter
             new_link: Skapa ny site
@@ -83,7 +83,7 @@ sv:
             cancel: Avbryt
             update: Uppdatera Site
             is_mirrored: Speglad
-      
+
         layouts:
           created: Layout skapad
           creation_failure: Misslyckades att skapa site
@@ -91,7 +91,7 @@ sv:
           update_failure: Uppdatering av layout misslyckades
           deleted: Layout borttagen
           not_found: Layout kunde inte hittas
-          
+
           index:
             title: Layouter
             new_link: Skapa ny layout
@@ -116,7 +116,7 @@ sv:
             create: Skapa Layout
             cancel: Avbryt
             update: Uppdatera Layout
-      
+
         pages:
           created: Sida skapad
           creation_failure: Misslyckades att skapa sida
@@ -125,7 +125,7 @@ sv:
           deleted: Sidan borttagen
           not_found: Sida kunde inte hittas
           layout_not_found: Kunde inte hitta layout. Vänligen skapa en.
-          
+
           index:
             title: Sidor
             new_link: Skapa ny sida
@@ -153,7 +153,7 @@ sv:
             no_tags: |-
               Layout har inga innehållstaggar definierade.<br/>
               Ändra innehållet så att det innehåller en sid eller fält tagg. Exempelvis: <code>{{cms:page:content}}</code>
-      
+
         snippets:
           created: Snippet skapad
           creation_failure: Misslyckades att skapa snippet
@@ -161,7 +161,7 @@ sv:
           update_failure: Uppdateringen av snippet misslyckades
           deleted: Snippet borttagen
           not_found: Snippet kunde inte hittas
-          
+
           index:
             title: Snippets
             new_link: Skapa Ny Snippet
@@ -178,12 +178,12 @@ sv:
             create: Skapa Snippet
             cancel: Avbryt
             update: Uppdatera Snippet
-      
+
         revisions:
           reverted: Innehåll återställt
           record_not_found: Kunde inte hitta data för återställning
           not_found: Återställningspunkt inte hittad
-          
+
           show:
             title: Revisioner för
             revision: Revision
@@ -194,7 +194,7 @@ sv:
             changes: Changes
             previous: Previous
             current: Nuvarande
-      
+
         files:
           created: Filer uppladdade
           creation_failure: Kunde inte skapa fil
@@ -202,7 +202,8 @@ sv:
           update_failure: Kunde inte uppdatera fil
           deleted: Fil borttagen
           not_found: Kunde inte hitta fil
-          
+          open_library: Open files library
+
           index:
             title: Filer
             new_link: Ladda upp en ny fil
@@ -223,7 +224,7 @@ sv:
             are_you_sure: Är du säker?
           file:
             are_you_sure: Är du säker?
-            
+
         categories:
           index:
             label: Kategorier
@@ -238,3 +239,8 @@ sv:
             save: Spara
           form:
             label: Kategorier
+
+        live_preview:
+          refresh: Refresh
+          refreshing: Refreshing
+          new_window: New Window

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -202,6 +202,7 @@ uk:
           update_failure: Не вдалося оновити файл
           deleted: Файл видалено
           not_found: Файл не знайдено
+          open_library: Open files library
 
           index:
             title: Файли
@@ -240,3 +241,8 @@ uk:
             save: Save
           form:
             label: Зберегти
+
+        live_preview:
+          refresh: Refresh
+          refreshing: Refreshing
+          new_window: New Window

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -39,20 +39,20 @@ zh-CN:
         description: 描述
       comfy/cms/snippet:
         identifier: 标识符
-        
+
   comfy:
     cms:
       content:
         site_not_found: 站点不存在
         layout_not_found: 布局不存在
         page_not_found: 页面不存在
-      
+
     admin:
       cms:
         base:
           site_not_found: 没有该站点
           fixtures_enabled: CMS夹具已经启用，在此处的所有修改将被忽略。
-          
+
           sites: 站点
           layouts: 布局
           pages: 页面
@@ -66,7 +66,7 @@ zh-CN:
           update_failure: 站点更新失败
           deleted: 站点删除成功
           not_found: 站点不存在
-          
+
           index:
             title: 站点
             new_link: 创建站点
@@ -91,7 +91,7 @@ zh-CN:
           update_failure: 布局更新失败
           deleted: 布局删除成功
           not_found: 布局不存在
-          
+
           index:
             title: 布局
             new_link: 创建新布局
@@ -125,7 +125,7 @@ zh-CN:
           deleted: 页面删除成功
           not_found: 页面不存在
           layout_not_found: 没有布局，请先创建一个布局。
-          
+
           index:
             title: 页面
             new_link: 创建新页面
@@ -161,7 +161,7 @@ zh-CN:
           update_failure: 片段更新失败
           deleted: 片段删除成功
           not_found: 片段不存在
-          
+
           index:
             title: 片段
             new_link: 创建新片段
@@ -183,7 +183,7 @@ zh-CN:
           reverted: 内容恢复成功
           record_not_found: 记录不存在
           not_found: 修订版本不存在
-          
+
           show:
             title: 修订版本属于
             revision: 修订版本
@@ -202,7 +202,8 @@ zh-CN:
           update_failure: 文件更新失败
           deleted: 文件删除成功
           not_found: 文件不存在
-          
+          open_library: Open files library
+
           index:
             title: 文件
             new_link: 上传新文件
@@ -223,7 +224,7 @@ zh-CN:
             are_you_sure: 确定删除该文件吗？
           file:
             are_you_sure: 确定删除该文件吗？
-            
+
         categories:
           index:
             label: 分类
@@ -238,3 +239,8 @@ zh-CN:
             save: 保存
           form:
             label: 分类
+
+        live_preview:
+          refresh: Refresh
+          refreshing: Refreshing
+          new_window: New Window

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -39,20 +39,20 @@ zh-TW:
         description: 描述
       comfy/cms/snippet:
         identifier: 標識符
-        
+
   comfy:
     cms:
       content:
         site_not_found: 站點不存在
         layout_not_found: 佈局不存在
         page_not_found: 頁面不存在
-      
+
     admin:
       cms:
         base:
           site_not_found: 沒有該站點
           fixtures_enabled: CMS夾具已經啟用，在此處的所有修改將被忽略。
-          
+
           sites: 站點
           layouts: 佈局
           pages: 頁面
@@ -66,7 +66,7 @@ zh-TW:
           update_failure: 站點更新失敗
           deleted: 站點刪除成功
           not_found: 站點不存在
-          
+
           index:
             title: 站點
             new_link: 創建站點
@@ -91,7 +91,7 @@ zh-TW:
           update_failure: 佈局更新失敗
           deleted: 佈局刪除成功
           not_found: 佈局不存在
-          
+
           index:
             title: 佈局
             new_link: 創建新佈局
@@ -125,7 +125,7 @@ zh-TW:
           deleted: 頁面刪除成功
           not_found: 頁面不存在
           layout_not_found: 沒有佈局，請先創建一個佈局。
-          
+
           index:
             title: 頁面
             new_link: 創建新頁面
@@ -161,7 +161,7 @@ zh-TW:
           update_failure: 片段更新失敗
           deleted: 片段刪除成功
           not_found: 片段不存在
-          
+
           index:
             title: 片段
             new_link: 創建新片段
@@ -183,7 +183,7 @@ zh-TW:
           reverted: 內容恢復成功
           record_not_found: 記錄不存在
           not_found: 修訂版本不存在
-          
+
           show:
             title: 修訂版本屬於
             revision: 修訂版本
@@ -202,7 +202,8 @@ zh-TW:
           update_failure: 文件更新失敗
           deleted: 文件刪除成功
           not_found: 文件不存在
-          
+          open_library: Open files library
+
           index:
             title: 文件
             new_link: 上傳新文件
@@ -223,7 +224,7 @@ zh-TW:
             are_you_sure: 確定刪除該文件嗎？
           file:
             are_you_sure: 確定刪除該文件嗎？
-            
+
         categories:
           index:
             label: 分類
@@ -238,3 +239,8 @@ zh-TW:
             save: 保存
           form:
             label: 分類
+
+        live_preview:
+          refresh: Refresh
+          refreshing: Refreshing
+          new_window: New Window


### PR DESCRIPTION
This pull request adds a live-preview to the Pages add/edit form. Maybe it is something you like.
It's configurable via data attributes on the Pages add/edit form and automatically disabled (shows the old "preview" button) on small screens.

In action: https://docs.google.com/file/d/0Byd7rfwOIEzYWjB4cnh4R2NKTms/edit?usp=drivesdk
