### PR TITLE
Importing bootstrap-sprockets is all we need.

### DIFF
--- a/app/assets/javascripts/comfy/admin/cms/application.js.coffee
+++ b/app/assets/javascripts/comfy/admin/cms/application.js.coffee
@@ -9,7 +9,6 @@
 #= require codemirror/modes/xml
 #= require codemirror/addons/edit/closetag
 #= require bootstrap-sprockets
-#= require bootstrap
 #= require comfy/admin/cms/lib/bootstrap-datetimepicker
 #= require comfy/admin/cms/lib/diff
 #= require comfy/admin/cms/lib/redactor


### PR DESCRIPTION
from the bootstrap-sass docs: bootstrap-sprockets and bootstrap should not both be included in application.js. https://github.com/twbs/bootstrap-sass/issues/829#issuecomment-75153827

If both are there some Bootstrap scripts such as the button dropdowns stop working.