### PR TITLE
Prepend page path to slug input field.

### DIFF
--- a/app/views/comfy/admin/cms/pages/_form.html.haml
+++ b/app/views/comfy/admin/cms/pages/_form.html.haml
@@ -10,9 +10,7 @@
 = form.text_field :label, :data => {:slugify => @page.new_record?}
 
 - unless @site.pages.count == 0 || @site.pages.root == @page
-  = form.text_field :slug, :data => {:slug => true}
-  - unless @page.new_record?
-    = form.text_field :full_path, :id => 'full-path', :disabled => true
+  = form.text_field :slug, :data => {:slug => true}, :prepend => @page.full_path.gsub(/\/#{@page.slug}$/, '/')
 
 - if (options = ::Comfy::Cms::Layout.options_for_select(@site)).present?
   = form.select :layout_id, options, {}, 'data-url' => form_blocks_comfy_admin_cms_site_page_path(@site, @page.id.to_i)


### PR DESCRIPTION
I had a couple of users who had problems understanding the disabled input for [full-path](https://s3.amazonaws.com/f.cl.ly/items/0b440F0t1s0j1I3N0T1s/Bildschirmfoto%202015-03-06%20um%2013.58.10.png) when editing a page. Especially when they change the slug but the full path does not change [while typing](https://s3.amazonaws.com/f.cl.ly/items/1K0B1Z0O1d0S1U0f3G1J/Bildschirmfoto%202015-03-06%20um%2013.58.27.png).

I changed the form and made it look like this:
![screenshot](https://s3.amazonaws.com/f.cl.ly/items/0R1N1V3j2E0a1u3j2H1j/Bildschirmfoto%202015-03-06%20um%2013.57.41.png)