### PR TITLE
URGENT: deleting one mirrored site deletes all content

### DIFF
--- a/app/models/comfy/cms/site.rb
+++ b/app/models/comfy/cms/site.rb
@@ -57,8 +57,7 @@ class Comfy::Cms::Site < ActiveRecord::Base
   # When removing entire site, let's not destroy content from other sites
   # Since before_destroy doesn't really work, this does the trick
   def destroy
-    self.class.where(:id => self.id).update_all(:is_mirrored => false) if self.is_mirrored?
-    # self.update_attributes(:is_mirrored => false) if self.is_mirrored?
+    self.update_attributes(:is_mirrored => false) if self.is_mirrored?
     super
   end
 

--- a/app/models/comfy/cms/site.rb
+++ b/app/models/comfy/cms/site.rb
@@ -58,6 +58,7 @@ class Comfy::Cms::Site < ActiveRecord::Base
   # Since before_destroy doesn't really work, this does the trick
   def destroy
     self.class.where(:id => self.id).update_all(:is_mirrored => false) if self.is_mirrored?
+    # self.update_attributes(:is_mirrored => false) if self.is_mirrored?
     super
   end
 

--- a/test/lib/mirrors_test.rb
+++ b/test/lib/mirrors_test.rb
@@ -228,18 +228,31 @@ class MirrorsTest < ActiveSupport::TestCase
   end
   
   def test_site_destruction
-    site = comfy_cms_sites(:default)
-    Comfy::Cms::Site.update_all(:is_mirrored => true) # bypassing callbacks
-    
-    mirror = Comfy::Cms::Site.create!(
-      :identifier   => 'mirror',
-      :hostname     => 'mirror.host',
-      :is_mirrored  => true
-    )
-    mirror.reload
-    assert_no_difference ['site.layouts.count', 'site.pages.count', 'site.snippets.count'] do
-      mirror.destroy
-      site.reload
+    Comfy::Cms::Site.delete_all
+    Comfy::Cms::Page.delete_all
+
+    site_a = Comfy::Cms::Site.create!(
+        :identifier => 'site-a',
+        :hostname   => 'site-a.test',
+        :is_mirrored => true)
+    site_b = Comfy::Cms::Site.create!(
+        :identifier => 'site-b',
+        :hostname   => 'site-b.test',
+        :is_mirrored => true)
+    site_c = Comfy::Cms::Site.create!(
+        :identifier => 'site-c',
+        :hostname   => 'site-c.test',
+        :is_mirrored => true)
+
+    assert_difference 'Comfy::Cms::Page.count', 3 do
+      layout = site_a.layouts.create!(:identifier => 'default')
+      site_a.pages.create!(
+          :label  => 'default',
+          :layout => layout)
+    end
+
+    assert_difference ['Comfy::Cms::Site.count', 'Comfy::Cms::Page.count'], -1 do
+      Comfy::Cms::Site.first.destroy
     end
   end
   


### PR DESCRIPTION
Current implementation of preventing this isn't work.

While loading has_many relations, AR sets inverse links for they.

```
[1] pry(main)> s = Comfy::Cms::Site.first
...
[2] pry(main)> [s.__id__, s.layouts.first.site.__id__]
...
=> [70315183268680, 70315183268680]
[3] pry(main)> s.__id__ == s.layouts.first.site.__id__
=> true
```

Will be great if you can release update soon.