### PR TITLE
Fix refresh CodeMirror when tab becomes active.

### DIFF
--- a/app/assets/javascripts/comfy/admin/cms/base.js.coffee
+++ b/app/assets/javascripts/comfy/admin/cms/base.js.coffee
@@ -106,7 +106,7 @@ window.CMS.codemirror = ->
       cm.setSize($(@).width(), $(@).height())
       cm.refresh()
 
-  $('a[data-toggle="tab"]').on 'shown', ->
+  $('a[data-toggle="tab"]').on 'shown.bs.tab', ->
     for cm in CMS.code_mirror_instances
       cm.refresh()
 


### PR DESCRIPTION
Bootstrap 3 changed the event name for tabs.