### PR TITLE
Add possibility to configure where a new page shall be inserted

### DIFF
--- a/app/models/comfy/cms/page.rb
+++ b/app/models/comfy/cms/page.rb
@@ -96,8 +96,19 @@ protected
   def assign_position
     return unless self.parent
     return if self.position.to_i > 0
+    ComfortableMexicanSofa.config.insert_page_at_beginning ? assign_position_at_beginning : assign_position_at_end
+  end
+
+  def assign_position_at_end
     max = self.parent.children.maximum(:position)
     self.position = max ? max + 1 : 0
+  end
+
+  def assign_position_at_beginning
+    self.position = 0
+    self.parent.children.each do |child|
+      child.update(position: child.position + 1)
+    end
   end
 
   def validate_target_page

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -92,6 +92,11 @@ ComfortableMexicanSofa.configure do |config|
   # Default is false.
   #   config.reveal_cms_partials = false
 
+  # Where should a new page be inserted? At the beginning of a partial
+  # tree or at the end? The default is always at the end. You can
+  # change this by setting the following option to true
+  #  config.insert_page_at_beginning = true
+
 end
 
 # Default credentials for ComfortableMexicanSofa::AccessControl::AdminAuthentication

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -75,21 +75,24 @@ class ComfortableMexicanSofa::Configuration
   # Auto-setting parameter derived from the routes
   attr_accessor :public_cms_path
 
+  # Where to insert a page in the tree
+  attr_accessor :insert_page_at_beginning
+
   # Configuration defaults
   def initialize
-    @cms_title            = 'ComfortableMexicanSofa CMS Engine'
-    @base_controller      = 'ApplicationController'
-    @admin_auth           = 'ComfortableMexicanSofa::AccessControl::AdminAuthentication'
-    @admin_authorization  = 'ComfortableMexicanSofa::AccessControl::AdminAuthorization'
-    @public_auth          = 'ComfortableMexicanSofa::AccessControl::PublicAuthentication'
-    @seed_data_path       = nil
-    @admin_route_redirect = ''
-    @enable_sitemap       = true
-    @upload_file_options  = { }
-    @enable_fixtures      = false
-    @fixtures_path        = File.expand_path('db/cms_fixtures', Rails.root)
-    @revisions_limit      = 25
-    @locales              = {
+    @cms_title                 = 'ComfortableMexicanSofa CMS Engine'
+    @base_controller           = 'ApplicationController'
+    @admin_auth                = 'ComfortableMexicanSofa::AccessControl::AdminAuthentication'
+    @admin_authorization       = 'ComfortableMexicanSofa::AccessControl::AdminAuthorization'
+    @public_auth               = 'ComfortableMexicanSofa::AccessControl::PublicAuthentication'
+    @seed_data_path            = nil
+    @admin_route_redirect      = ''
+    @enable_sitemap            = true
+    @upload_file_options       = { }
+    @enable_fixtures           = false
+    @fixtures_path             = File.expand_path('db/cms_fixtures', Rails.root)
+    @revisions_limit           = 25
+    @locales                   = {
       'cs'    => 'Česky',
       'da'    => 'Dansk',
       'de'    => 'Deutsch',
@@ -108,14 +111,15 @@ class ComfortableMexicanSofa::Configuration
       'zh-CN' => '简体中文',
       'zh-TW' => '正體中文'
     }
-    @admin_locale         = nil
-    @admin_cache_sweeper  = nil
-    @allow_irb            = false
-    @allowed_helpers      = nil
-    @allowed_partials     = nil
-    @hostname_aliases     = nil
-    @reveal_cms_partials  = false
-    @public_cms_path      = nil
+    @admin_locale              = nil
+    @admin_cache_sweeper       = nil
+    @allow_irb                 = false
+    @allowed_helpers           = nil
+    @allowed_partials          = nil
+    @hostname_aliases          = nil
+    @reveal_cms_partials       = false
+    @public_cms_path           = nil
+    @insert_page_at_beginning  = false
   end
 
 end


### PR DESCRIPTION
This PR allows the developer to decide, where a new page should
be inserted, when a new page is created. A new configuration option
called insert_page_at_beginning was added. The default is false.
If set to true, the new page will be inserted at the beginning
of a partial tree.

Technically the new page will have position 0 and all other
pages are updated with page.position = page.position + 1
