### PR TITLE
preselect-compatible block query in cms_block* helpers

### DIFF
--- a/app/helpers/comfy/cms_helper.rb
+++ b/app/helpers/comfy/cms_helper.rb
@@ -51,7 +51,7 @@ module Comfy::CmsHelper
   #   cms_block_content(:left_column, CmsPage.first)
   #   cms_block_content(:left_column) # if @cms_page is present
   def cms_block_content(identifier, blockable = @cms_page)
-    tag = blockable && (block = blockable.blocks.find_by_identifier(identifier)) && block.tag
+    tag = blockable && (block = blockable.blocks.find{|b| b.identifier == identifier.to_s}) && block.tag
     return '' unless tag
     tag.content
   end
@@ -59,14 +59,14 @@ module Comfy::CmsHelper
   # For those times when we need to render content that shouldn't be renderable
   # Example: {{cms:field}} tags
   def cms_block_content_render(identifier, blockable = @cms_page)
-    tag = blockable && (block = blockable.blocks.find_by_identifier(identifier)) && block.tag
+    tag = blockable && (block = blockable.blocks.find{|b| b.identifier == identifier.to_s}) && block.tag
     return '' unless tag
     render :inline => ComfortableMexicanSofa::Tag.process_content(blockable, tag.content)
   end
 
   # Same as cms_block_content but with cms tags expanded
   def cms_block_render(identifier, blockable = @cms_page)
-    tag = blockable && (block = blockable.blocks.find_by_identifier(identifier)) && block.tag
+    tag = blockable && (block = blockable.blocks.find{|b| b.identifier == identifier.to_s}) && block.tag
     return '' unless tag
     render :inline => ComfortableMexicanSofa::Tag.process_content(blockable, tag.render)
   end


### PR DESCRIPTION
The cms_block_\* helpers, which I found myself frequently using, are generating SQL SELECT query for each call. This introduces N+1 select problem. Preselecting blocks with .includes(:blocks) ActiveRecord feature does not help.

This change forces ActiveRecord to select entire blocks collection for the page. It does well with .includes(:blocks): if blocks were preselected, then they are not selected second time.

The blocks collection preselection itself is a necessary move — it's unlikely you'll want to pick a single block of the page, more likely you want to pick multiple blocks. Even in case of a single block, the introduced overhead will be small.
