### PR TITLE
Fix asset URL generation when the CMS is not mounted at the root

### DIFF
--- a/lib/comfortable_mexican_sofa/tags/asset.rb
+++ b/lib/comfortable_mexican_sofa/tags/asset.rb
@@ -10,14 +10,15 @@ class ComfortableMexicanSofa::Tag::Asset
     return unless (layout = Comfy::Cms::Layout.find_by_identifier(identifier))
     type    = params[0]
     format  = params[1]
-    
+
+    base = ComfortableMexicanSofa.config.public_cms_path || ''
     case type
     when 'css'
-      out = "/cms-css/#{blockable.site.id}/#{identifier}/#{layout.cache_buster}.css"
+      out = "#{base}/cms-css/#{blockable.site.id}/#{identifier}/#{layout.cache_buster}.css"
       out = "<link href='#{out}' media='screen' rel='stylesheet' type='text/css' />" if format == 'html_tag'
       out
     when 'js'
-      out = "/cms-js/#{blockable.site.id}/#{identifier}/#{layout.cache_buster}.js"
+      out = "#{base}/cms-js/#{blockable.site.id}/#{identifier}/#{layout.cache_buster}.js"
       out = "<script src='#{out}' type='text/javascript'></script>" if format == 'html_tag'
       out
     end

--- a/test/lib/tags/asset_test.rb
+++ b/test/lib/tags/asset_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../test_helper'
 
 class AssetTagTest < ActiveSupport::TestCase
-  
+
   def test_initialize_tag
     assert tag = ComfortableMexicanSofa::Tag::Asset.initialize_tag(
       comfy_cms_pages(:default), '{{ cms:asset:default:css:html_tag }}'
@@ -9,7 +9,7 @@ class AssetTagTest < ActiveSupport::TestCase
     assert_equal 'default', tag.identifier
     assert_equal ['css', 'html_tag'], tag.params
   end
-  
+
   def test_initialize_tag_failure
     [
       '{{cms:asset}}',
@@ -21,14 +21,14 @@ class AssetTagTest < ActiveSupport::TestCase
       )
     end
   end
-  
+
   def test_render_no_params
     tag = ComfortableMexicanSofa::Tag::Asset.initialize_tag(
       comfy_cms_pages(:default), '{{ cms:asset:default }}'
     )
     assert_equal '', tag.render
   end
-  
+
   def test_render_for_css
     site = comfy_cms_sites(:default)
     layout = site.layouts.last
@@ -37,13 +37,30 @@ class AssetTagTest < ActiveSupport::TestCase
       comfy_cms_pages(:default), "{{ cms:asset:#{layout.identifier}:css }}"
     )
     assert_equal "/cms-css/#{site.id}/#{layout.identifier}/#{layout.cache_buster}.css", tag.render
-    
+
     tag = ComfortableMexicanSofa::Tag::Asset.initialize_tag(
       comfy_cms_pages(:default), "{{ cms:asset:#{layout.identifier}:css:html_tag }}"
     )
     assert_equal "<link href='/cms-css/#{site.id}/#{layout.identifier}/#{layout.cache_buster}.css' media='screen' rel='stylesheet' type='text/css' />", tag.render
   end
-  
+
+  def test_render_for_css_with_non_root_mount
+    site = comfy_cms_sites(:default)
+    layout = site.layouts.last
+
+    ComfortableMexicanSofa.config.public_cms_path = '/custom'
+
+    tag = ComfortableMexicanSofa::Tag::Asset.initialize_tag(
+      comfy_cms_pages(:default), "{{ cms:asset:#{layout.identifier}:css }}"
+    )
+    assert_equal "/custom/cms-css/#{site.id}/#{layout.identifier}/#{layout.cache_buster}.css", tag.render
+
+    tag = ComfortableMexicanSofa::Tag::Asset.initialize_tag(
+      comfy_cms_pages(:default), "{{ cms:asset:#{layout.identifier}:css:html_tag }}"
+    )
+    assert_equal "<link href='/custom/cms-css/#{site.id}/#{layout.identifier}/#{layout.cache_buster}.css' media='screen' rel='stylesheet' type='text/css' />", tag.render
+  end
+
   def test_render_for_js
     site = comfy_cms_sites(:default)
     layout = site.layouts.last
@@ -52,11 +69,27 @@ class AssetTagTest < ActiveSupport::TestCase
       comfy_cms_pages(:default), "{{ cms:asset:#{layout.identifier}:js }}"
     )
     assert_equal "/cms-js/#{site.id}/#{layout.identifier}/#{layout.cache_buster}.js", tag.render
-    
+
     tag = ComfortableMexicanSofa::Tag::Asset.initialize_tag(
       comfy_cms_pages(:default), "{{ cms:asset:#{layout.identifier}:js:html_tag }}"
     )
     assert_equal "<script src='/cms-js/#{site.id}/#{layout.identifier}/#{layout.cache_buster}.js' type='text/javascript'></script>", tag.render
   end
-  
+
+  def test_render_for_js_with_non_root_mount
+    site = comfy_cms_sites(:default)
+    layout = site.layouts.last
+
+    ComfortableMexicanSofa.config.public_cms_path = '/custom'
+
+    tag = ComfortableMexicanSofa::Tag::Asset.initialize_tag(
+      comfy_cms_pages(:default), "{{ cms:asset:#{layout.identifier}:js }}"
+    )
+    assert_equal "/custom/cms-js/#{site.id}/#{layout.identifier}/#{layout.cache_buster}.js", tag.render
+
+    tag = ComfortableMexicanSofa::Tag::Asset.initialize_tag(
+      comfy_cms_pages(:default), "{{ cms:asset:#{layout.identifier}:js:html_tag }}"
+    )
+    assert_equal "<script src='/custom/cms-js/#{site.id}/#{layout.identifier}/#{layout.cache_buster}.js' type='text/javascript'></script>", tag.render
+  end
 end


### PR DESCRIPTION
When the CMS is mounted like this:

      comfy_route :cms_admin, :path => '/admin/cms'
      comfy_route :cms, :path => '/cms', :sitemap => true

The asset URIs does not include ```ComfortableMexicanSofa.config.public_cms_path```.  