### PR TITLE
Use site locale when rendering previews.

### DIFF
--- a/app/controllers/comfy/admin/cms/pages_controller.rb
+++ b/app/controllers/comfy/admin/cms/pages_controller.rb
@@ -1,5 +1,4 @@
 class Comfy::Admin::Cms::PagesController < Comfy::Admin::Cms::BaseController
-
   before_action :check_for_layouts, :only => [:new, :edit]
   before_action :build_cms_page,    :only => [:new, :create]
   before_action :load_cms_page,     :only => [:edit, :update, :destroy]
@@ -131,6 +130,10 @@ protected
       @cms_site   = @page.site
       @cms_layout = @page.layout
       @cms_page   = @page
+
+      # Make sure to use the site locale to render the preview becaue it might
+      # be different from the admin locale.
+      I18n.locale = @cms_site.locale
 
       # Chrome chokes on content with iframes. Issue #434
       response.headers['X-XSS-Protection'] = '0'

--- a/test/controllers/comfy/admin/cms/pages_controller_test.rb
+++ b/test/controllers/comfy/admin/cms/pages_controller_test.rb
@@ -449,6 +449,28 @@ class Comfy::Admin::Cms::PagesControllerTest < ActionController::TestCase
     end
   end
 
+  def test_preview_language
+    site = @site
+    site.update_columns(:locale => 'de')
+    layout = comfy_cms_layouts(:default)
+
+    assert_equal :en, I18n.locale
+
+    post :create, :site_id => site, :preview => 'Preview', :page => {
+      :label      => 'Test Page',
+      :slug       => 'test-page',
+      :parent_id  => comfy_cms_pages(:default).id,
+      :layout_id  => layout.id,
+      :blocks_attributes => [
+        { :identifier => 'default_page_text',
+          :content    => 'preview content' }
+      ]
+    }
+
+    assert_response :success
+    assert_equal :de, I18n.locale
+  end
+
   def test_get_new_with_no_layout
     Comfy::Cms::Layout.destroy_all
     get :new, :site_id => @site


### PR DESCRIPTION
Make sure to use the page site locale when rendering previews because it might be different from the admin locale.