### PR TITLE
When renaming index on 'down' step use table names from before update

### DIFF
--- a/db/upgrade_migrations/08_upgrade_to_1_12_0.rb
+++ b/db/upgrade_migrations/08_upgrade_to_1_12_0.rb
@@ -65,11 +65,11 @@ class UpgradeTo1120 < ActiveRecord::Migration
     rename_table :comfy_cms_blocks,           :cms_blocks
     rename_table :comfy_cms_snippets,         :cms_snippets
     rename_table :comfy_cms_files,            :cms_files
-    rename_index :cms_revisions,
+    rename_index :comfy_cms_revisions,
       'index_cms_revisions_on_record_type_id_and_created',
       'index_cms_revisions_on_record_type_and_record_id_and_created_at'
     rename_table :comfy_cms_revisions,        :cms_revisions
-    rename_index :cms_categories,
+    rename_index :comfy_cms_categories,
       'index_cms_categories_on_site_id_and_cat_type_and_label',
       'index_cms_categories_on_site_id_and_categorized_type_and_label'
     rename_table :comfy_cms_categories,       :cms_categories


### PR DESCRIPTION
There seems to be a bug in the upgrade migration. When renaming indexes, the migration uses the new (anticipated in the next line of code) name for the table. But, it should still use the old name OR we should reverse the order of lines of code.