### PR TITLE
Make rescue_from Page not found errors configurable

### DIFF
--- a/app/controllers/comfy/cms/content_controller.rb
+++ b/app/controllers/comfy/cms/content_controller.rb
@@ -8,7 +8,11 @@ class Comfy::Cms::ContentController < Comfy::Cms::BaseController
                 :authenticate,
                 :only => :show
 
-  rescue_from ActiveRecord::RecordNotFound, :with => :page_not_found
+  if ComfortableMexicanSofa.config.rescue_from_404
+    rescue_from ActiveRecord::RecordNotFound, :with => :page_not_found
+  else
+    self.rescue_handlers.delete(["ActiveRecord::RecordNotFound", :page_not_found])
+  end
 
   def show
     if @cms_page.target_page.present?

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -92,6 +92,10 @@ ComfortableMexicanSofa.configure do |config|
   # Default is false.
   #   config.reveal_cms_partials = false
 
+  # Rescue from page not found errors inside CMS?
+  # Exceptions from child controllers are not propageted up to ApplicationController since Rails 4
+  config.rescue_from_404 = true
+
 end
 
 # Default credentials for ComfortableMexicanSofa::AccessControl::AdminAuthentication

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -75,6 +75,9 @@ class ComfortableMexicanSofa::Configuration
   # Auto-setting parameter derived from the routes
   attr_accessor :public_cms_path
 
+  # Rescue from 'page not found' errors
+  attr_accessor :rescue_from_404
+
   # Configuration defaults
   def initialize
     @cms_title            = 'ComfortableMexicanSofa CMS Engine'
@@ -116,6 +119,7 @@ class ComfortableMexicanSofa::Configuration
     @hostname_aliases     = nil
     @reveal_cms_partials  = false
     @public_cms_path      = nil
+    @rescue_from_404      = true
   end
 
 end

--- a/test/integration/rescue_not_found_test.rb
+++ b/test/integration/rescue_not_found_test.rb
@@ -1,0 +1,20 @@
+require_relative '../test_helper'
+
+class RescueNotFoundTest < ActionDispatch::IntegrationTest
+
+  def setup
+    ComfortableMexicanSofa.configure { |config| config.rescue_from_404 = false }
+    load File.expand_path("../../../app/controllers/comfy/cms/content_controller.rb", __FILE__)
+  end
+
+  def teardown
+    reset_config
+    load File.expand_path("../../../app/controllers/comfy/cms/content_controller.rb", __FILE__)
+  end
+
+  def test_do_not_rescue_from_404
+    assert_exception_raised ActiveRecord::RecordNotFound do
+      get '/doesnotexist'
+    end
+  end
+end

--- a/test/lib/configuration_test.rb
+++ b/test/lib/configuration_test.rb
@@ -27,6 +27,7 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal nil, config.allowed_partials
     assert_equal nil, config.allowed_templates
     assert_equal nil, config.hostname_aliases
+    assert_equal true, config.rescue_from_404
   end
 
   def test_initialization_overrides

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,6 +47,7 @@ class ActiveSupport::TestCase
       config.allowed_templates    = nil
       config.hostname_aliases     = nil
       config.public_cms_path      = nil
+      config.rescue_from_404      = true
     end
     ComfortableMexicanSofa::AccessControl::AdminAuthentication.username = 'username'
     ComfortableMexicanSofa::AccessControl::AdminAuthentication.password = 'password'


### PR DESCRIPTION
Since Rails 4 'Exceptions raised inside exception handlers are not propagated up'.
Therefore, ActionController::RoutingError raised in the Comfy::Cms::ContentController cannot be rescued from the application controllers. We can make the call to rescue_from inside ContentController conditional (NOTICE: this workaround won't work if we simply pass if: condition as an option to rescue_from, it just can't be called at all).

Let me know your thoughts and if you agree to go this way I'll prepare some tests.
