### PR TITLE
Fix load_admin_site when params[:site_id] returns nil

### DIFF
--- a/app/controllers/comfy/admin/cms/base_controller.rb
+++ b/app/controllers/comfy/admin/cms/base_controller.rb
@@ -32,7 +32,7 @@ class Comfy::Admin::Cms::BaseController < ComfortableMexicanSofa.config.base_con
 protected
 
   def load_admin_site
-    if @site = ::Comfy::Cms::Site.find_by_id(params[:site_id] || session[:site_id]) || ::Comfy::Cms::Site.first
+    if @site = ::Comfy::Cms::Site.find_by_id(params.fetch(:site_id, '') || session[:site_id]) || ::Comfy::Cms::Site.first
       session[:site_id] = @site.id
     else
       I18n.locale = ComfortableMexicanSofa.config.admin_locale || I18n.default_locale


### PR DESCRIPTION
When setting up a vanilla Comfy by using the default user, creating
a site and then log out and in again, I receive this strange SQL query
which resulst in an exception:

Mysql2::Error: Unknown column 'id.id' in 'where clause': SELECT  `comfy_cms_sites`.* FROM `comfy_cms_sites` WHERE `id`.`id` = 2 AND `id`.`label` = ' aesis' AND `id`.`identifier` = 'aesis' AND `id`.`hostname` = 'localhost' AND `id`.`path` = '' AND `id`.`locale` = 'en' AND `id`.`is_mirrored` = 0 LIMIT 1
Completed 500 Internal Server Error in 969969ms (ActiveRecord: 12.8ms)
** [Airbrake] Notice was not sent due to configuration:
  Environment Monitored? false
  API key set? false

Mysql2::Error - Unknown column 'id.id' in 'where clause':
(output ommited)
activerecord (4.2.1) lib/active_record/dynamic_matchers.rb:70:in `find_by_id'
/Users/andwen/project/sumcumo/comfortable-mexican-sofa/app/controllers/comfy/admin/cms/base_controller.rb:36:in `load_admin_site'
activesupport (4.2.1) lib/active_support/callbacks.rb:432:in `block in make_lambda'

The problem is:

if @site = ::Comfy::Cms::Site.find_by_id(params[:site_id] || session[:site_id]) || ::Comfy::Cms::Site.first

because the param site_id is not set and after logging out, the session site_id is
also not set. To circumvent this, find_by_id needs to receive a valid value.

This patch is simply fixing this by using:

params.fetch(:site_id, '')

what will result in an empty String instead of nil.