### PR TITLE
ensure base ends with a slash and don't put in an extra slash.

### DIFF
--- a/lib/comfortable_mexican_sofa/tags/asset.rb
+++ b/lib/comfortable_mexican_sofa/tags/asset.rb
@@ -12,13 +12,17 @@ class ComfortableMexicanSofa::Tag::Asset
     format  = params[1]
 
     base = ComfortableMexicanSofa.config.public_cms_path || ''
+    unless base.ends_with?("/") # => true
+      base = base + "/"
+    end
+
     case type
     when 'css'
-      out = "#{base}/cms-css/#{blockable.site.id}/#{identifier}/#{layout.cache_buster}.css"
+      out = "#{base}cms-css/#{blockable.site.id}/#{identifier}/#{layout.cache_buster}.css"
       out = "<link href='#{out}' media='screen' rel='stylesheet' type='text/css' />" if format == 'html_tag'
       out
     when 'js'
-      out = "#{base}/cms-js/#{blockable.site.id}/#{identifier}/#{layout.cache_buster}.js"
+      out = "#{base}cms-js/#{blockable.site.id}/#{identifier}/#{layout.cache_buster}.js"
       out = "<script src='#{out}' type='text/javascript'></script>" if format == 'html_tag'
       out
     end


### PR DESCRIPTION
If your site is running at a location of '', the cms-css link urls were getting a location of '//cms-css/SITE_ID/IDENTIFIER' and double slashes make for bad links.