### PR TITLE
Enable sort for children layouts

### DIFF
--- a/app/views/comfy/admin/cms/layouts/_index_branch.html.haml
+++ b/app/views/comfy/admin/cms/layouts/_index_branch.html.haml
@@ -20,4 +20,5 @@
         = layout.identifier
 
   - if layout.children.present?
-    %ul= render :partial => 'index_branch', :collection => layout.children
+    %ul.children.sortable
+      = render :partial => 'index_branch', :collection => layout.children


### PR DESCRIPTION
The layouts list is not enabling sub layouts to be sorted due to
a missing class (`.sortable`). This fixes it by adding the missing
class. Copies over the behaviour of the index_branch for the sites
index action.