### PR TITLE
Fix find_site with custom public cms path.

### DIFF
--- a/app/models/comfy/cms/site.rb
+++ b/app/models/comfy/cms/site.rb
@@ -37,6 +37,10 @@ class Comfy::Cms::Site < ActiveRecord::Base
   def self.find_site(host, path = nil)
     return Comfy::Cms::Site.first if Comfy::Cms::Site.count == 1
     cms_site = nil
+
+    public_cms_path = ComfortableMexicanSofa.configuration.public_cms_path
+    path.gsub!(/\A#{public_cms_path}/, '') unless path.nil? || public_cms_path == '/'
+
     Comfy::Cms::Site.where(:hostname => real_host_from_aliases(host)).each do |site|
       if site.path.blank?
         cms_site = site

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -156,6 +156,22 @@ class CmsSiteTest < ActiveSupport::TestCase
   def test_url_with_public_cms_path
     ComfortableMexicanSofa.config.public_cms_path = '/custom'
     assert_equal '//test.host/custom/', comfy_cms_sites(:default).url
+
+    site_a = Comfy::Cms::Site.create!(:identifier => 'test_a', :hostname => 'test2.host', :path => 'en')
+    site_b = Comfy::Cms::Site.create!(:identifier => 'test_b', :hostname => 'test2.host', :path => 'fr')
+
+    assert_equal nil,     Comfy::Cms::Site.find_site('test2.host')
+    assert_equal nil,     Comfy::Cms::Site.find_site('test2.host', '/custom/some/path')
+    assert_equal site_a,  Comfy::Cms::Site.find_site('test2.host', '/custom/en')
+    assert_equal site_a,  Comfy::Cms::Site.find_site('test2.host', '/custom/en?a=b')
+    assert_equal site_a,  Comfy::Cms::Site.find_site('test2.host', '/custom/en/some/path?a=b')
+
+    assert_equal nil,     Comfy::Cms::Site.find_site('test2.host', '/custom/english/some/path')
+
+    assert_equal site_b,  Comfy::Cms::Site.find_site('test2.host', '/custom/fr')
+    assert_equal site_b,  Comfy::Cms::Site.find_site('test2.host', '/custom/fr?a=b')
+    assert_equal site_b,  Comfy::Cms::Site.find_site('test2.host', '/custom/fr/some/path')
+    assert_equal site_b,  Comfy::Cms::Site.find_site('test2.host', '/custom/fr/some/path?a=b')
   end
   
 end


### PR DESCRIPTION
When having multiple sites under the same hostname, find_site will do
some regex to find the correct site by path. This regex does not take
into account a custom public cms path.
