### PR TITLE
Automatically assign uploaded files to currently selected category

### DIFF
--- a/app/controllers/comfy/admin/cms/files_controller.rb
+++ b/app/controllers/comfy/admin/cms/files_controller.rb
@@ -40,6 +40,7 @@ class Comfy::Admin::Cms::FilesController < Comfy::Admin::Cms::BaseController
   end
 
   def create
+    @file.category_ids = @site.categories.where(label: params[:category]).inject({}) {|hash, category| hash.merge category.id => 1} if params[:category]
     @file.save!
 
     case params[:source]

--- a/app/views/comfy/admin/cms/files/index.html.haml
+++ b/app/views/comfy/admin/cms/files/index.html.haml
@@ -24,7 +24,7 @@
 :javascript
   $(function(){
     window.CMS.uploader($("#cms-uploader"), {
-      url: '#{comfy_admin_cms_site_files_path(@site, :source => :plupload)}',
+      url: '#{comfy_admin_cms_site_files_path(@site, :source => :plupload, :category => params[:category])}',
       multipart_params: {
         '#{request_forgery_protection_token}': '#{form_authenticity_token}',
         '#{Rails.application.config.session_options[:key]}': '#{request.session_options[:id]}'

--- a/test/controllers/comfy/admin/cms/files_controller_test.rb
+++ b/test/controllers/comfy/admin/cms/files_controller_test.rb
@@ -216,4 +216,19 @@ class Comfy::Admin::Cms::FilesControllerTest < ActionController::TestCase
     assert_equal 1, file_one.position
     assert_equal 0, file_two.position
   end
+
+  def test_create_as_plupload_with_selected_category
+    assert_difference 'Comfy::Cms::File.count' do
+      post :create,
+        :source   => 'plupload',
+        :site_id  => @site,
+        :file     => {
+          :file => fixture_file_upload('files/image.jpg', 'image/jpeg')
+        },
+        :category => [comfy_cms_categories(:default).label]
+      assert_response :success
+      assert_no_select "body"
+      assert_select "tr[id=comfy_cms_file_#{Comfy::Cms::File.last.id}] .category", comfy_cms_categories(:default).label
+    end
+  end
 end


### PR DESCRIPTION
Fix for #674. This will automatically assign new uploaded files to the currently selected category/categories.
