### PR TITLE
Provide multiple app view paths

### DIFF
--- a/app/models/comfy/cms/layout.rb
+++ b/app/models/comfy/cms/layout.rb
@@ -45,10 +45,12 @@ class Comfy::Cms::Layout < ActiveRecord::Base
   end
   
   # List of available application layouts
-  def self.app_layouts_for_select
-    Dir.glob(File.expand_path('app/views/layouts/**/*.html.*', Rails.root)).collect do |filename|
-      filename.gsub!("#{File.expand_path('app/views/layouts', Rails.root)}/", '')
-      filename.split('/').last[0...1] == '_' ? nil : filename.split('.').first
+  def self.app_layouts_for_select(view_paths)
+    view_paths.map(&:to_s).select { |path| path.start_with?(Rails.root.to_s) }.flat_map do |full_path|
+      Dir.glob("#{full_path}/layouts/**/*.html.*").collect do |filename|
+        filename.gsub!("#{full_path}/layouts/", '')
+        filename.split('/').last[0...1] == '_' ? nil : filename.split('.').first
+      end.compact.sort
     end.compact.sort
   end
   

--- a/app/views/comfy/admin/cms/layouts/_form.html.haml
+++ b/app/views/comfy/admin/cms/layouts/_form.html.haml
@@ -5,7 +5,7 @@
 - if (options = Comfy::Cms::Layout.options_for_select(@site, @layout)).present?
   = form.select :parent_id, [["---- #{t('.select_parent_layout')} ----", nil]] + options
 
-- if (options = Comfy::Cms::Layout.app_layouts_for_select).present?
+- if (options = Comfy::Cms::Layout.app_layouts_for_select(lookup_context.view_paths)).present?
   = form.select :app_layout, [["---- #{t('.select_app_layout')} ----", nil]] + options
 
 = form.text_area :content, :data => {'cms-cm-mode' => 'text/html'}

--- a/test/models/layout_test.rb
+++ b/test/models/layout_test.rb
@@ -54,12 +54,23 @@ class CmsLayoutTest < ActiveSupport::TestCase
     FileUtils.touch(File.expand_path('app/views/layouts/comfy/admin/cms/nested.html.erb', Rails.root))
     FileUtils.touch(File.expand_path('app/views/layouts/comfy/_partial.html.erb', Rails.root))
     FileUtils.touch(File.expand_path('app/views/layouts/comfy/not_a_layout.erb', Rails.root))
-    
-    assert_equal ['comfy/admin/cms', 'comfy/admin/cms/nested'], Comfy::Cms::Layout.app_layouts_for_select
-    
+
+    view_paths = [File.expand_path('app/views/', Rails.root)]
+    assert_equal ['comfy/admin/cms', 'comfy/admin/cms/nested'], Comfy::Cms::Layout.app_layouts_for_select(view_paths)
+  ensure
     FileUtils.rm(File.expand_path('app/views/layouts/comfy/admin/cms/nested.html.erb', Rails.root))
     FileUtils.rm(File.expand_path('app/views/layouts/comfy/_partial.html.erb', Rails.root))
     FileUtils.rm(File.expand_path('app/views/layouts/comfy/not_a_layout.erb', Rails.root))
+  end
+
+  def test_multiple_view_paths
+    FileUtils.mkdir_p(File.expand_path('app/additional_views/layouts', Rails.root))
+    FileUtils.touch(File.expand_path('app/additional_views/layouts/additional_layout.html.erb', Rails.root))
+
+    view_paths = [File.expand_path('app/views/', Rails.root), File.expand_path('app/additional_views', Rails.root)]
+    assert_equal ['additional_layout', 'comfy/admin/cms'], Comfy::Cms::Layout.app_layouts_for_select(view_paths)
+  ensure
+    FileUtils.rm_r(File.expand_path('app/additional_views', Rails.root))
   end
   
   def test_merged_content_with_same_child_content


### PR DESCRIPTION
We are building application with multiple themes. Views of each theme resides in app/themes; we are change view_path in request context. But right now Sofa doesn't process configuration with multiple view paths correctly.
