### PR TITLE
Rails5 passing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,20 @@ gemfile:
   - test/gemfiles/Gemfile.rails.4.0
   - test/gemfiles/Gemfile.rails.4.1
   - test/gemfiles/Gemfile.rails.4.2
+  - test/gemfiles/Gemfile.rails.5.0
 branches:
   only:
     - master
+    - "rails5-passing-tests"
 matrix:
   fast_finish: true
   include:
-    - rvm: 2.2.0
+    - rvm: 2.3.0
       gemfile: test/gemfiles/Gemfile.rails.master
+  exclude:
+    - rvm: 2.0.0
+      gemfile: test/gemfiles/Gemfile.rails.5.0
+    - rvm: 2.1.8
+      gemfile: test/gemfiles/Gemfile.rails.5.0
   allow_failures:
     - gemfile: test/gemfiles/Gemfile.rails.master

--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,5 @@ group :test do
   gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
   gem 'mocha',      :require => false
   gem 'coveralls',  :require => false
+  gem 'rails-controller-testing'
 end

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ComfortableMexicanSofa
 [![Gem Version](https://img.shields.io/gem/v/comfortable_mexican_sofa.svg?style=flat)](http://rubygems.org/gems/comfortable_mexican_sofa) [![Gem Downloads](https://img.shields.io/gem/dt/comfortable_mexican_sofa.svg?style=flat)](http://rubygems.org/gems/comfortable_mexican_sofa) [![Build Status](https://img.shields.io/travis/comfy/comfortable-mexican-sofa.svg?style=flat)](https://travis-ci.org/comfy/comfortable-mexican-sofa) [![Dependency Status](https://img.shields.io/gemnasium/comfy/comfortable-mexican-sofa.svg?style=flat)](https://gemnasium.com/comfy/comfortable-mexican-sofa) [![Code Climate](https://img.shields.io/codeclimate/github/comfy/comfortable-mexican-sofa.svg?style=flat)](https://codeclimate.com/github/comfy/comfortable-mexican-sofa) [![Coverage Status](https://img.shields.io/coveralls/comfy/comfortable-mexican-sofa.svg?style=flat)](https://coveralls.io/r/comfy/comfortable-mexican-sofa?branch=master)
 
-ComfortableMexicanSofa is a powerful Rails 4 CMS Engine
+ComfortableMexicanSofa is a powerful Rails 4/5 CMS Engine
 
 ## Features
 

--- a/app/controllers/comfy/admin/cms/files_controller.rb
+++ b/app/controllers/comfy/admin/cms/files_controller.rb
@@ -108,7 +108,8 @@ protected
   end
 
   def file_params
-    unless (file = params[:file]).is_a?(Hash)
+    file = params[:file]
+    unless file.is_a?(Hash) || file.respond_to?(:to_unsafe_hash)
       params[:file] = { }
       params[:file][:file] = file
     end

--- a/app/models/comfy/cms/page.rb
+++ b/app/models/comfy/cms/page.rb
@@ -118,8 +118,7 @@ protected
   def sync_child_full_paths!
     return unless full_path_changed?
     children.each do |p|
-      p.update_column(:full_path, p.send(:assign_full_path))
-      p.send(:sync_child_full_paths!)
+      p.update_attribute(:full_path, p.send(:assign_full_path))
     end
   end
 

--- a/app/views/comfy/admin/cms/sites/_mirrors.html.haml
+++ b/app/views/comfy/admin/cms/sites/_mirrors.html.haml
@@ -10,7 +10,7 @@
   - when ::Comfy::Cms::Snippet
     - object.mirrors.collect{|m| [m.site.label, edit_comfy_admin_cms_site_snippet_path(m.site, m)]}
   - else
-    - (::Comfy::Cms::Site.mirrored - [@site]).collect{|s| [s.label, url_for(params.merge(:site_id => s))]}
+    - (::Comfy::Cms::Site.mirrored - [@site]).collect{|s| [s.label, url_for(params.permit!.merge(:site_id => s))]}
 
 - options = [[@site.label, request.fullpath]] + options
 

--- a/comfortable_mexican_sofa.gemspec
+++ b/comfortable_mexican_sofa.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency 'rails',             '>= 4.0.0', '< 5'
+  s.add_dependency 'rails',             '>= 4.0.0', '< 5.1'
   s.add_dependency 'rails-i18n',        '>= 4.0.0'
   s.add_dependency 'bootstrap_form',    '>= 2.2.0'
   s.add_dependency 'active_link_to',    '>= 1.0.0'

--- a/lib/comfortable_mexican_sofa/routes/cms.rb
+++ b/lib/comfortable_mexican_sofa/routes/cms.rb
@@ -16,7 +16,7 @@ class ActionDispatch::Routing::Mapper
             :format       => :xml
         end
 
-        get '/:format' => 'content#show', :as => 'render_page', :path => "(*cms_path)"
+        get '/' => 'content#show', :as => 'render_page', :path => "(*cms_path)"
       end
     end
   end

--- a/test/controllers/comfy/admin/cms/files_controller_test.rb
+++ b/test/controllers/comfy/admin/cms/files_controller_test.rb
@@ -173,9 +173,8 @@ class Comfy::Admin::Cms::FilesControllerTest < ActionController::TestCase
   end
 
   def test_update_failure
-    file = comfy_cms_files(:default)
     put :update, :site_id => @site, :id => @file, :file => {
-      :file => nil
+      :file_file_name => ""
     }
     assert_response :success
     assert_template :edit

--- a/test/gemfiles/Gemfile.rails.5.0
+++ b/test/gemfiles/Gemfile.rails.5.0
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-gem 'rails',            :github => 'rails/rails'
+gem 'rails',            '~> 5.0.0'
 gem 'bootstrap_form',   '>= 2.2.0'
 gem 'active_link_to',   '>= 1.0.0'
 gem 'paperclip',        '>= 3.4.0'

--- a/test/integration/access_control_test.rb
+++ b/test/integration/access_control_test.rb
@@ -140,7 +140,7 @@ class AccessControlTest < ActionDispatch::IntegrationTest
   def test_public_authentication_custom
     with_routing do |routes|
       routes.draw do
-        get '/:format' => 'access_control_test/test_authentication/content#show', :path => "(*cms_path)"
+        get '/' => 'access_control_test/test_authentication/content#show', :path => "(*cms_path)"
       end
 
       get '/'
@@ -152,7 +152,7 @@ class AccessControlTest < ActionDispatch::IntegrationTest
   def test_public_authorization_custom
     with_routing do |routes|
       routes.draw do
-        get '/:format' => 'access_control_test/test_authorization/content#show', :path => "(*cms_path)"
+        get '/' => 'access_control_test/test_authorization/content#show', :path => "(*cms_path)"
       end
 
       get '/'

--- a/test/lib/fixtures/files_test.rb
+++ b/test/lib/fixtures/files_test.rb
@@ -83,7 +83,7 @@ class FixtureFilesTest < ActiveSupport::TestCase
   end
 
   def test_export
-    comfy_cms_files(:default).update_column(:block_id, comfy_cms_blocks(:default_field_text))
+    comfy_cms_files(:default).update_attribute(:block, comfy_cms_blocks(:default_field_text))
 
     host_path = File.join(ComfortableMexicanSofa.config.fixtures_path, 'test-site')
     attr_path = File.join(host_path, 'files/_sample.jpg.yml')

--- a/test/models/file_test.rb
+++ b/test/models/file_test.rb
@@ -103,7 +103,7 @@ class CmsFileTest < ActiveSupport::TestCase
     assert file.block.blank?
     assert_equal 1, Comfy::Cms::File.not_page_file.count
     
-    file.update_column(:block_id, comfy_cms_blocks(:default_field_text))
+    file.update_attribute(:block, comfy_cms_blocks(:default_field_text))
     assert_equal 0, Comfy::Cms::File.not_page_file.count
   end
   


### PR DESCRIPTION
This fork made the minimal updates on the tests and code to get comfy working on rails 5 and passing all the tests in 4.0, 4.1, 4.2 and 5.0 as specified in the .travis.yml file
The minimal updates means that there were no unnecessary syntax changes or calls to methods to avoid deprecation messages