### PR TITLE
Use plural term for “Revisions” on portuguese I18n

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -109,9 +109,9 @@ pt-BR:
             revision: &revision
               zero: '%{count} Revisão'
               one: '%{count} Revisão'
-              few: '%{count} Revisão'
-              many: '%{count} Revisão'
-              other: '%{count} Revisão'
+              few: '%{count} Revisões'
+              many: '%{count} Revisões'
+              other: '%{count} Revisões'
           form:
             select_parent_layout: Selecione o Leiaute Pai
             select_app_layout: Selecione o Leiaute da Aplicação


### PR DESCRIPTION
Hello @GBH,

First, thank you very much for this incredible gem. Couldn't be more feature complete and simple! Incredible coding here! 🎉.

I'm opening this PR with the following goal: quick fix the "Revisions" plural term in Brazilian Portuguese at the admin area. Here are the screenshots:

## Before

<img width="984" alt="before" src="https://cloud.githubusercontent.com/assets/1538066/23202405/1a030dc0-f8de-11e6-9bf9-d2d31ad4c2b1.png">

## After

<img width="993" alt="after" src="https://cloud.githubusercontent.com/assets/1538066/23202404/19ff9d52-f8de-11e6-8124-3c012bd212f3.png">

