### PR TITLE
Add a single column 'mobile' stylesheet for windows 768px and under.

### DIFF
--- a/app/assets/stylesheets/comfy/admin/cms/application.sass
+++ b/app/assets/stylesheets/comfy/admin/cms/application.sass
@@ -9,3 +9,4 @@
 @import "comfy/admin/cms/redactor_overrides"
 @import "comfy/admin/cms/base"
 @import "comfy/admin/cms/custom"
+@import "comfy/admin/cms/mobile"

--- a/app/assets/stylesheets/comfy/admin/cms/mobile.scss
+++ b/app/assets/stylesheets/comfy/admin/cms/mobile.scss
@@ -1,0 +1,62 @@
+@media screen and (max-width: 768px){
+    body#comfy:not(.in-iframe) .body-wrapper {
+	display: flex;
+	flex-flow: column nowrap;
+	height: unset;
+	min-height: 100%;
+	
+	div.center-column, div.left-column, div.right-column{
+	    display: block;
+	    position: unset;
+	    margin: 0;
+	    width: 100%;
+	    float: none;
+
+	    div.left-column-content {
+		padding: 0.25em 0;
+	    }
+	    
+	    >div,
+	    div.center-column-content,
+	    div.left-column-content,
+	    div.right-column-content {
+		display: block;
+		position: unset;
+		width: 100%;
+	    }
+	}
+	>div.left-column{
+	    margin: 0;
+	    order: 1;
+	}
+	>div.right-column{
+	    margin: 0;
+	    order: 2;
+	    div.right-column-content{
+		padding: 0.1em 0.2em;
+	    }
+	}
+	>div.center-column{
+	    display: flex;
+	    flex-flow: column nowrap;
+	    flex: 1;
+	    margin: 0;
+	    order: 3;
+	    >div.center-column-content{
+		flex:1;
+	    }
+	}
+    }
+
+    .modal .modal-dialog {
+	margin: 0.1em;
+    }
+
+}
+
+@media screen and (max-width:400px){
+    ul.list .item .btn-group {
+	clear: both;
+	margin-top: 0.5em;
+    }
+}


### PR DESCRIPTION
This is just a stylesheet that uses Flexbox to turn the three columns into rows when the viewport is under 768px. It's a little kludgy, but I use it due to working with thin browser windows most of the time.

Also, I think we should consider changing application.sass into application.scss, because that lets it use file globbing to import everything in the folder. Importing ./* and ./lib/* could replace the bulk of the file unless the order is important.