### PR TITLE
Avoids initing twice

### DIFF
--- a/app/assets/javascripts/comfy/admin/cms/base.js.coffee
+++ b/app/assets/javascripts/comfy/admin/cms/base.js.coffee
@@ -2,7 +2,8 @@ window.CMS ||= {}
 
 window.CMS.code_mirror_instances = [ ]
 
-$ -> window.CMS.init()
+unless Turbolinks?.controller? # Turbolinks 5 verification
+  $ -> window.CMS.init()
 $(document).on 'page:load turbolinks:load', -> window.CMS.init()
 
 window.CMS.init = ->

--- a/app/assets/javascripts/comfy/admin/cms/lib/diff.js.coffee
+++ b/app/assets/javascripts/comfy/admin/cms/lib/diff.js.coffee
@@ -1,7 +1,11 @@
 #= require comfy/admin/cms/lib/diff/diff_match_patch.min
 #= require comfy/admin/cms/lib/diff/pretty_text_diff.min
 
-$(document).on 'page:load ready turbolinks:load', ->
+unless Turbolinks?.controller? # Turbolinks 5 verification
+  $ -> initDiff()
+$(document).on 'page:load turbolinks:load', -> initDiff()
+
+initDiff = ->
   $("table.diff").prettyTextDiff ->
     cleanup: true
     originalContainer:  'tr td.original'


### PR DESCRIPTION
Turbolinks 5 emits turbolinks:load on page load and after every turbolinks visit. This verifies if it's turbolinks 5 and don't trigger initiation on jQuery ready. The version check was taken from https://github.com/turbolinks/turbolinks/issues/6