### PR TITLE
add the missing translations for zh-CN and zh-TW

### DIFF
--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -6,7 +6,7 @@ zh-CN:
       comfy/cms/page: 页面
       comfy/cms/snippet: 片段
       comfy/cms/file: 文件
-      comfy/cms/translation: Translation
+      comfy/cms/translation: 翻译
 
     attributes:
       comfy/cms/site:
@@ -41,10 +41,10 @@ zh-CN:
         label: 标签
         content: 内容
       comfy/cms/translation:
-        locale: Language
-        label: Label
-        layout_id: Layout
-        is_published: Published
+        locale: 语言
+        label: 标签
+        layout_id: 布局
+        is_published: 发布
 
   comfy:
     cms:
@@ -153,25 +153,25 @@ zh-CN:
               编辑内容使其包含一个页面或者field标签。例如： <code>{{cms:wysiwyg content}}</code>
 
         translations:
-          created: Translation created
-          creation_failure: Failed to create translation
-          updated: Translation updated
-          update_failure: Failed to update translation
-          deleted: Translation deleted
-          not_found: Translation not found
+          created: 翻译创建成功
+          creation_failure: 翻译创建失败
+          updated: 翻译更新成功
+          update_failure: 翻译更新失败
+          deleted: 翻译删除成功
+          not_found: 翻译不存在
 
           new:
-            title: New Translation
+            title: 新翻译
           edit:
-            title: Editing Translation
+            title: 编辑翻译
           form:
-            preview: Preview
-            create: Create
-            update: Update
-            cancel: Return to Page
+            preview: 预览
+            create: 创建
+            update: 更新
+            cancel: 取消
           sidebar:
-            new: New Translation
-            confirm: Are you sure?
+            new: 新翻译
+            confirm: 确定吗?
 
         snippets:
           created: 片段创建成功

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -171,7 +171,7 @@ zh-CN:
             cancel: 取消
           sidebar:
             new: 新翻译
-            confirm: 确定吗?
+            confirm: 确定刪除该翻译吗?
 
         snippets:
           created: 片段创建成功

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -26,8 +26,8 @@ zh-CN:
       comfy/cms/page:
         label: 页面名称
         layout_id: 布局
-        slug: Slug
-        full_path: Full path
+        slug: 缩略路径
+        full_path: 完整路径
         parent_id: 上级
         target_page_id: 跳转至
         content: 内容
@@ -57,7 +57,7 @@ zh-CN:
       cms:
         base:
           site_not_found: 没有该站点
-          seeds_enabled: CMS夹具已经启用，在此处的所有修改将被忽略。
+          seeds_enabled: CMS样板已经启用，在此处的所有修改将被忽略。
 
           sites: 站点
           layouts: 布局
@@ -144,7 +144,7 @@ zh-CN:
             create: 创建页面
             cancel: 取消
             update: 更新页面
-            choose_link: Select page...
+            choose_link: 选择页面...
 
         fragments:
           form_fragments:
@@ -206,10 +206,10 @@ zh-CN:
             revision: 修订版本
             update: 更新到该修订版本
             cancel: 取消
-            content: Content
-            changes: Changes
-            previous: Previous
-            current: Current
+            content: 内容
+            changes: 更改
+            previous: 先前
+            current: 当前
           sidebar:
             revision:
               zero: '%{count} 修订版本'

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -57,7 +57,7 @@ zh-TW:
       cms:
         base:
           site_not_found: 沒有該站點
-          seeds_enabled: CMS 樣板已經啟用，在此處的所有修改將被忽略。
+          seeds_enabled: CMS樣板已經啟用，在此處的所有修改將被忽略。
 
           sites: 站點
           layouts: 佈局
@@ -113,7 +113,7 @@ zh-TW:
             select_parent_layout: 選擇上級佈局
             select_app_layout: 選擇應用佈局
             create: 創建佈局
-            cancel: Cancel
+            cancel: 取消
             update: 更新佈局
 
         pages:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -171,7 +171,7 @@ zh-TW:
             cancel: 取消
           sidebar:
             new: 新翻譯
-            confirm: 確定麼?
+            confirm: 確定刪除該翻譯嗎?
 
         snippets:
           created: 片段創建成功

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -6,7 +6,7 @@ zh-TW:
       comfy/cms/page: 頁面
       comfy/cms/snippet: 片段
       comfy/cms/file: 文件
-      comfy/cms/translation: Translation
+      comfy/cms/translation: 翻譯
 
     attributes:
       comfy/cms/site:
@@ -41,10 +41,10 @@ zh-TW:
         label: 標籤
         content: 內容
       comfy/cms/translation:
-        locale: Language
-        label: Label
-        layout_id: Layout
-        is_published: Published
+        locale: 語言
+        label: 標籤
+        layout_id: 佈局
+        is_published: 發佈
 
   comfy:
     cms:
@@ -153,25 +153,25 @@ zh-TW:
               編輯內容使其包含一個頁面或者欄位標記。例如： <code>{{cms:wysiwyg content}}</code>
 
         translations:
-          created: Translation created
-          creation_failure: Failed to create translation
-          updated: Translation updated
-          update_failure: Failed to update translation
-          deleted: Translation deleted
-          not_found: Translation not found
+          created: 翻譯創建成功
+          creation_failure: 翻譯創建失敗
+          updated: 翻譯更新成功
+          update_failure: 翻譯更新失敗
+          deleted: 翻譯刪除成功
+          not_found: 翻譯不存在
 
           new:
-            title: New Translation
+            title: 新翻譯
           edit:
-            title: Editing Translation
+            title: 編輯翻譯
           form:
-            preview: Preview
-            create: Create
-            update: Update
-            cancel: Return to Page
+            preview: 預覽
+            create: 創建
+            update: 更新
+            cancel: 取消
           sidebar:
-            new: New Translation
-            confirm: Are you sure?
+            new: 新翻譯
+            confirm: 確定麼?
 
         snippets:
           created: 片段創建成功


### PR DESCRIPTION
### Summary

This PR adds the missing translations for the locale of 简体中文 and 正體中文

Related to [#771](https://github.com/comfy/comfortable-mexican-sofa/issues/771)
