### PR TITLE
Fix reorder glitchiness caused by file drag'n'drop

### DIFF
--- a/app/assets/javascripts/comfy/admin/cms/uploader.js.coffee
+++ b/app/assets/javascripts/comfy/admin/cms/uploader.js.coffee
@@ -68,18 +68,22 @@
       # Show drag and drop info and attach events if drag and drop is
       # supported and enabled.
       if up.settings.dragdrop and up.features.dragdrop
-        drop_element = $(up.settings.drop_element)
+        dropElement = $(up.settings.drop_element).get(0)
 
         # When dragging over the document add a class to the drop target
         # that puts it ontop of every element and remove that class when
         # dropping or leaving the drop target. Otherwise the dragleave
         # event would fire whenever we dragging over a child element inside
         # the drop target such as text nodes or stuff.
-        $(document).bind 'dragenter', (e) ->
-          drop_element.addClass('cms-uploader-drag-drop-target-active')
-
-        drop_element.bind 'drop dragleave', (e) ->
-          drop_element.removeClass('cms-uploader-drag-drop-target-active')
+        activeClass = 'cms-uploader-drag-drop-target-active'
+        document.addEventListener 'dragenter', (e) ->
+          # Only react to drag'n'drops that contain a file. See:
+          # https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/types
+          if e.dataTransfer.types.indexOf('Files') != -1
+            dropElement.classList.add(activeClass)
+        for eventName in ['drop', 'dragleave']
+          dropElement.addEventListener eventName, ->
+            dropElement.classList.remove(activeClass)
 
       else
         $('.cms-uploader-drag-drop-info', target).hide()


### PR DESCRIPTION
Fixes glitchiness when reordering caused by file drag'n'drop reacting to all types of payloads. Now the files drag'n'drop only reacts to files.
