### PR TITLE
Content processing code clean-up

### DIFF
--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -45,6 +45,7 @@ class ComfortableMexicanSofa::Configuration
   attr_accessor :admin_cache_sweeper
 
   # Not allowing erb code to be run inside page content. False by default.
+  # @return [Boolean]
   attr_accessor :allow_erb
 
   # Whitelist of all helper methods that can be used via {{cms:helper}} tag. By default

--- a/lib/comfortable_mexican_sofa/content/params_parser.rb
+++ b/lib/comfortable_mexican_sofa/content/params_parser.rb
@@ -1,54 +1,67 @@
+require 'strscan'
+
 module ComfortableMexicanSofa::Content::ParamsParser
 
   class Error < StandardError; end
 
-  SINGLE_STRING_LITERAL = %r{'[^']*'}
-  DOUBLE_STRING_LITERAL = %r{"[^"]*"}
-  IDENTIFIER            = %r{[a-z0-9][\w\-/.]*}i
-  COLUMN                = %r{:}
-  COMMA                 = %r{,}
+  STRING_LITERAL = %r{'[^']*'|"[^"]*"}
+  IDENTIFIER     = %r{[a-z0-9][\w\-/.]*}i
+  COLON          = %r{:}
+  COMMA          = %r{,}
 
+  # @param [String] text
+  # @return [Array<String, {String => String}>]
+  # @raise [Error] if the given `text` is malformed.
+  #
+  # @example
+  #   parse("happy greeting name:Joe show:true")
+  #   #=> ['happy', 'greeting', {'name' => 'Joe', 'show' => 'true'}]
   def self.parse(text)
-    parameterize(slice(tokenize(text.to_s)))
+    parse_token_groups(split_on_commas(tokenize(text.to_s)))
   end
 
-  def self.parameterize(token_groups)
-    params = []
-    token_groups.each do |tokens|
-      if tokens.count == 1
-        collect_param_for_string!(params, tokens[0])
-      elsif tokens.count == 3
-        collect_param_for_hash!(params, tokens)
+  # @param [Enumerable<Array<(Symbol, String)>>] token_groups
+  # @return [Array<String, {String => String}>]
+  def self.parse_token_groups(token_groups)
+    token_groups.each_with_object([]) do |tokens, params|
+      case tokens.count
+      when 1
+        params << parse_string_param(tokens[0])
+      when 3
+        param = parse_key_value_param(tokens)
+        params.last.is_a?(Hash) ? params.last.update(param) : params << param
       else
         raise Error, "Unexpected tokens found: #{tokens}"
       end
     end
-    params
   end
 
-  def self.collect_param_for_string!(params, token)
+  # @param [(:string, String)] token
+  # @return [String]
+  # @raise [Error] if `token[0] != :string`.
+  def self.parse_string_param(token)
     type, value = token
     raise Error, "Unexpected token: #{token}" unless type == :string
-    params << value
+    value
   end
 
-  def self.collect_param_for_hash!(params, tokens)
-    key, col, val = tokens
-    key_type, key_value = key
-    col_type,           = col
-    val_type, val_value = val
-
-    unless key_type == :string && col_type == :column && val_type == :string
+  # @param [((:string, String), (:colon, String), (:string, String))] tokens
+  # @return [{String => String}]
+  # @raise [Error] if `tokens[0][0] != :string`, or `tokens[1][0] != :colon`,
+  #   or `tokens[2][0] != :string`.
+  def self.parse_key_value_param(tokens)
+    (key_type, key_value), (col_type, _col_value), (val_type, val_value) = tokens
+    unless key_type == :string && col_type == :colon && val_type == :string
       raise Error, "Unexpected tokens: #{tokens}"
     end
-
-    hash = params.last.is_a?(Hash) ? params.pop : {}
-    hash[key_value] = val_value
-    params << hash
+    { key_value => val_value }
   end
 
-  # grouping tokens based on the comma and also removing comma tokens
-  def self.slice(tokens)
+  # Splits tokens on commas. The result contains no `:comma` tokens.
+  #
+  # @param [Enumerable<(Symbol, String)>] tokens
+  # @return [Enumerable<Array<(Symbol, String)>>] Token groups.
+  def self.split_on_commas(tokens)
     slices = tokens.slice_after do |token|
       token[0] == :comma
     end
@@ -59,25 +72,24 @@ module ComfortableMexicanSofa::Content::ParamsParser
 
   # Tokenizing input string into a list of touples
   # Also args_string is stripped of "smart" quotes coming from wysiwyg
+  #
+  # @param [String] args_string
+  # @return [Array<String>] tokens
   def self.tokenize(args_string)
-    args_string.gsub!(%r{[“”]}, '"')
-    args_string.gsub!(%r{[‘’]}, "'")
-
-    tokens = []
+    args_string.tr!("“”‘’", %q(""''))
     ss = StringScanner.new(args_string)
-    until ss.eos?
+    tokens = []
+    loop do
       ss.skip(%r{\s*})
       break if ss.eos?
-      token =
-        if    (t = ss.scan(SINGLE_STRING_LITERAL)) then [:string, t[1...t.size - 1]]
-        elsif (t = ss.scan(DOUBLE_STRING_LITERAL)) then [:string, t[1...t.size - 1]]
-        elsif (t = ss.scan(IDENTIFIER))            then [:string, t]
-        elsif (t = ss.scan(COLUMN))                then [:column, t]
-        elsif (t = ss.scan(COMMA))                 then [:comma, t]
-        else
-          raise Error, "Unexpected char: #{ss.getch}"
-        end
-      tokens << token
+      tokens <<
+          if    (t = ss.scan(STRING_LITERAL)) then [:string, t[1...-1]]
+          elsif (t = ss.scan(IDENTIFIER))     then [:string, t]
+          elsif (t = ss.scan(COLON))          then [:colon, t]
+          elsif (t = ss.scan(COMMA))          then [:comma, t]
+          else
+            raise Error, "Unexpected char: #{ss.getch}"
+          end
     end
     tokens
   end

--- a/lib/comfortable_mexican_sofa/content/tag.rb
+++ b/lib/comfortable_mexican_sofa/content/tag.rb
@@ -2,8 +2,18 @@ class ComfortableMexicanSofa::Content::Tag
 
   class Error < StandardError; end
 
-  attr_reader :context, :params, :source
+  # @type [Comfy::Cms::WithFragments]
+  attr_reader :context
 
+  # @type [Array<String, {String => String}>] params
+  attr_reader :params
+
+  # @type [String, nil] source
+  attr_reader :source
+
+  # @param [Comfy::Cms::WithFragments] context
+  # @param [Array<String, {String => String}>] params
+  # @param [String, nil] source
   def initialize(context:, params: [], source: nil)
     @context  = context
     @params   = params
@@ -12,22 +22,25 @@ class ComfortableMexicanSofa::Content::Tag
 
   # Making sure we don't leak erb from tags by accident.
   # Tag classes can override this, like partials/helpers tags.
-  def allow_erb
-    false || ComfortableMexicanSofa.config.allow_erb
+  def allow_erb?
+    ComfortableMexicanSofa.config.allow_erb
   end
 
-  # Normally it's a string. However if tag content has tags, we need to expand
-  # them and that produces potentually more stuff
+  # Normally it's a {(String)}. However, if tag content has tags,
+  # we need to expand them and that produces potentially more stuff.
+  # @return [Array<String, ComfortableMexicanSofa::Content::Tag>]
   def nodes
     template  = ComfortableMexicanSofa::Content::Renderer.new(@context)
     tokens    = template.tokenize(content)
     template.nodes(tokens)
   end
 
+  # @return [String]
   def content
     raise Error, "This is a base class. It holds no content"
   end
 
+  # @return [String]
   def render
     content
   end

--- a/lib/comfortable_mexican_sofa/content/tags/file.rb
+++ b/lib/comfortable_mexican_sofa/content/tags/file.rb
@@ -10,10 +10,15 @@
 #
 class ComfortableMexicanSofa::Content::Tag::File < ComfortableMexicanSofa::Content::Tag::Fragment
 
-  attr_reader :as, :variant_attrs
+  # @type ["url", "link", "image"]
+  attr_reader :as
+
+  # @type [{String => String}]
+  attr_reader :variant_attrs
 
   delegate :rails_blob_path, to: "Rails.application.routes.url_helpers"
 
+  # @param (see ComfortableMexicanSofa::Content::Tag#initialize)
   def initialize(context:, params: [], source: nil)
     super
     @as             = options["as"] || "url"
@@ -61,10 +66,12 @@ class ComfortableMexicanSofa::Content::Tag::File < ComfortableMexicanSofa::Conte
 
 protected
 
+  # @return [ActiveStorage::Blob]
   def attachment
     fragment.attachments.first
   end
 
+  # @return [String]
   def label
     @label || attachment && attachment.filename
   end

--- a/lib/comfortable_mexican_sofa/content/tags/files.rb
+++ b/lib/comfortable_mexican_sofa/content/tags/files.rb
@@ -3,6 +3,7 @@
 #
 class ComfortableMexicanSofa::Content::Tag::Files < ComfortableMexicanSofa::Content::Tag::File
 
+  # @param (see ComfortableMexicanSofa::Content::Tag#initialize)
   def initialize(context:, params: [], source: nil)
     super
   end

--- a/lib/comfortable_mexican_sofa/content/tags/fragment.rb
+++ b/lib/comfortable_mexican_sofa/content/tags/fragment.rb
@@ -8,7 +8,10 @@
 #
 class ComfortableMexicanSofa::Content::Tag::Fragment < ComfortableMexicanSofa::Content::Tag
 
-  attr_reader :identifier, :renderable, :namespace, :options
+  attr_reader :identifier, :renderable, :namespace
+
+  # @type [{String => String}]
+  attr_reader :options
 
   def initialize(context:, params: [], source: nil)
     super
@@ -25,6 +28,7 @@ class ComfortableMexicanSofa::Content::Tag::Fragment < ComfortableMexicanSofa::C
   end
 
   # Grabs existing fragment record or spins up a new instance if there's none
+  # @return [Comfy::Cms::Fragment]
   def fragment
     context.fragments.detect { |f| f.identifier == identifier } ||
       context.fragments.build(identifier: identifier)

--- a/lib/comfortable_mexican_sofa/content/tags/helper.rb
+++ b/lib/comfortable_mexican_sofa/content/tags/helper.rb
@@ -21,7 +21,7 @@ class ComfortableMexicanSofa::Content::Tag::Helper < ComfortableMexicanSofa::Con
   end
 
   # we output erb into rest of the content
-  def allow_erb
+  def allow_erb?
     true
   end
 

--- a/lib/comfortable_mexican_sofa/content/tags/partial.rb
+++ b/lib/comfortable_mexican_sofa/content/tags/partial.rb
@@ -19,7 +19,7 @@ class ComfortableMexicanSofa::Content::Tag::Partial < ComfortableMexicanSofa::Co
   end
 
   # we output erb into rest of the content
-  def allow_erb
+  def allow_erb?
     true
   end
 

--- a/lib/comfortable_mexican_sofa/content/tags/template.rb
+++ b/lib/comfortable_mexican_sofa/content/tags/template.rb
@@ -18,7 +18,7 @@ class ComfortableMexicanSofa::Content::Tag::Template < ComfortableMexicanSofa::C
   end
 
   # we output erb into rest of the content
-  def allow_erb
+  def allow_erb?
     true
   end
 

--- a/test/lib/content/params_parser_test.rb
+++ b/test/lib/content/params_parser_test.rb
@@ -2,134 +2,119 @@ require_relative "../../test_helper"
 
 class ContentParamsParserTest < ActiveSupport::TestCase
 
+  PARSER = ComfortableMexicanSofa::Content::ParamsParser
+
   def test_tokenizer
-    tokens = ComfortableMexicanSofa::Content::ParamsParser.tokenize("param")
+    tokens = PARSER.tokenize("param")
     assert_equal [[:string, "param"]], tokens
   end
 
   def test_tokenizer_with_integer
-    tokens = ComfortableMexicanSofa::Content::ParamsParser.tokenize("123")
+    tokens = PARSER.tokenize("123")
     assert_equal [[:string, "123"]], tokens
   end
 
   def test_tokenizer_with_commas
-    tokens = ComfortableMexicanSofa::Content::ParamsParser.tokenize("param_a, param_b, param_c")
+    tokens = PARSER.tokenize("param_a, param_b, param_c")
     assert_equal [
       [:string, "param_a"], [:comma, ","], [:string, "param_b"], [:comma, ","], [:string, "param_c"]
     ], tokens
   end
 
   def test_tokenizer_with_columns
-    tokens = ComfortableMexicanSofa::Content::ParamsParser.tokenize("key: value")
-    assert_equal [[:string, "key"], [:column, ":"], [:string, "value"]], tokens
+    tokens = PARSER.tokenize("key: value")
+    assert_equal [[:string, "key"], [:colon, ":"], [:string, "value"]], tokens
   end
 
   def test_tokenizer_with_quoted_value
-    tokens = ComfortableMexicanSofa::Content::ParamsParser.tokenize("key: ''")
-    assert_equal [[:string, "key"], [:column, ":"], [:string, ""]], tokens
+    tokens = PARSER.tokenize("key: ''")
+    assert_equal [[:string, "key"], [:colon, ":"], [:string, ""]], tokens
 
-    tokens = ComfortableMexicanSofa::Content::ParamsParser.tokenize("key: 'test'")
-    assert_equal [[:string, "key"], [:column, ":"], [:string, "test"]], tokens
+    tokens = PARSER.tokenize("key: 'test'")
+    assert_equal [[:string, "key"], [:colon, ":"], [:string, "test"]], tokens
 
-    tokens = ComfortableMexicanSofa::Content::ParamsParser.tokenize("key: 'v1, v2: v3'")
-    assert_equal [[:string, "key"], [:column, ":"], [:string, "v1, v2: v3"]], tokens
+    tokens = PARSER.tokenize("key: 'v1, v2: v3'")
+    assert_equal [[:string, "key"], [:colon, ":"], [:string, "v1, v2: v3"]], tokens
 
-    tokens = ComfortableMexicanSofa::Content::ParamsParser.tokenize('key: "v1, v2: v3"')
-    assert_equal [[:string, "key"], [:column, ":"], [:string, "v1, v2: v3"]], tokens
+    tokens = PARSER.tokenize('key: "v1, v2: v3"')
+    assert_equal [[:string, "key"], [:colon, ":"], [:string, "v1, v2: v3"]], tokens
   end
 
   def test_tokenizer_with_smart_quotes
-    expected = [[:string, "param"], [:comma, ","], [:string, "key"], [:column, ":"], [:string, "value"]]
+    expected = [[:string, "param"], [:comma, ","], [:string, "key"], [:colon, ":"], [:string, "value"]]
 
-    tokens = ComfortableMexicanSofa::Content::ParamsParser.tokenize("'param', 'key': 'value'")
+    tokens = PARSER.tokenize("'param', 'key': 'value'")
     assert_equal expected, tokens
 
-    tokens = ComfortableMexicanSofa::Content::ParamsParser.tokenize('"param", "key": "value"')
+    tokens = PARSER.tokenize('"param", "key": "value"')
     assert_equal expected, tokens
 
-    tokens = ComfortableMexicanSofa::Content::ParamsParser.tokenize("“param”, “key”: “value”")
+    tokens = PARSER.tokenize("“param”, “key”: “value”")
     assert_equal expected, tokens
 
-    tokens = ComfortableMexicanSofa::Content::ParamsParser.tokenize("‘param’, ‘key’: ‘value’")
+    tokens = PARSER.tokenize("‘param’, ‘key’: ‘value’")
     assert_equal expected, tokens
   end
 
   def test_tokenizer_with_bad_input
     message = "Unexpected char: %"
-    assert_exception_raised ComfortableMexicanSofa::Content::ParamsParser::Error, message do
-      ComfortableMexicanSofa::Content::ParamsParser.tokenize("%")
+    assert_exception_raised PARSER::Error, message do
+      PARSER.tokenize("%")
     end
   end
 
-  def test_slice
+  def test_split_on_commas
     tokens = [[:string, "a"], [:comma, ","], [:string, "b"]]
-    token_groups = ComfortableMexicanSofa::Content::ParamsParser.slice(tokens)
+    token_groups = PARSER.split_on_commas(tokens)
     assert_equal [[[:string, "a"]], [[:string, "b"]]], token_groups
   end
 
-  def test_parameterize
+  def test_parse_token_groups
     token_groups = [[[:string, "a"]]]
-    params = ComfortableMexicanSofa::Content::ParamsParser.parameterize(token_groups)
+    params = PARSER.parse_token_groups(token_groups)
     assert_equal ["a"], params
 
-    token_groups = [[[:string, "a"], [:column, ":"], [:string, "b"]]]
-    params = ComfortableMexicanSofa::Content::ParamsParser.parameterize(token_groups)
+    token_groups = [[[:string, "a"], [:colon, ":"], [:string, "b"]]]
+    params = PARSER.parse_token_groups(token_groups)
     assert_equal [{ "a" => "b" }], params
   end
 
-  def test_parameterize_with_bad_input
+  def test_parse_token_groups_with_bad_input
     message = "Unexpected tokens found: [[:string, \"a\"], [:string, \"b\"]]"
     token_groups = [[[:string, "a"], [:string, "b"]]]
-    assert_exception_raised ComfortableMexicanSofa::Content::ParamsParser::Error, message do
-      ComfortableMexicanSofa::Content::ParamsParser.parameterize(token_groups)
+    assert_exception_raised PARSER::Error, message do
+      PARSER.parse_token_groups(token_groups)
     end
   end
 
-  def test_collect_param_for_string!
-    params = []
-    ComfortableMexicanSofa::Content::ParamsParser.collect_param_for_string!(params, [:string, "a"])
-    assert_equal ["a"], params
+  def test_parse_string_param
+    assert_equal "a", PARSER.parse_string_param([:string, "a"])
   end
 
-  def test_collect_param_for_string_with_bad_input
+  def test_parse_string_param_with_bad_input
     message = "Unexpected token: [:invalid, \"a\"]"
-    assert_exception_raised ComfortableMexicanSofa::Content::ParamsParser::Error, message do
-      ComfortableMexicanSofa::Content::ParamsParser.collect_param_for_string!([], [:invalid, "a"])
+    assert_exception_raised PARSER::Error, message do
+      PARSER.parse_string_param([:invalid, "a"])
     end
   end
 
-  def test_collect_param_for_hash!
-    params = []
-    tokens = [[:string, "a"], [:column, ":"], [:string, "b"]]
-    ComfortableMexicanSofa::Content::ParamsParser.collect_param_for_hash!(params, tokens)
-    assert_equal [{ "a" => "b" }], params
+  def test_parse_key_value_param
+    tokens = [[:string, "a"], [:colon, ":"], [:string, "b"]]
+    assert_equal({ "a" => "b" }, PARSER.parse_key_value_param(tokens))
   end
 
-  def test_collect_param_for_hash_with_trailing_hash
-    params = ["x", { "y" => "z" }]
-    tokens = [[:string, "a"], [:column, ":"], [:string, "b"]]
-    ComfortableMexicanSofa::Content::ParamsParser.collect_param_for_hash!(params, tokens)
-    assert_equal ["x", { "y" => "z", "a" => "b" }], params
-  end
-
-  def test_collect_param_for_hash_with_trailing_param
-    params = ["x", { "y" => "z" }, "k"]
-    tokens = [[:string, "a"], [:column, ":"], [:string, "b"]]
-    ComfortableMexicanSofa::Content::ParamsParser.collect_param_for_hash!(params, tokens)
-    assert_equal ["x", { "y" => "z" }, "k", { "a" => "b" }], params
-  end
-
-  def test_collect_param_for_hash_with_bad_input
+  def test_parse_key_value_param_with_bad_input
     message = "Unexpected tokens: [[:string, \"a\"], [:invalid, \":\"], [:string, \"b\"]]"
-    assert_exception_raised ComfortableMexicanSofa::Content::ParamsParser::Error, message do
-      tokens = [[:string, "a"], [:invalid, ":"], [:string, "b"]]
-      ComfortableMexicanSofa::Content::ParamsParser.collect_param_for_hash!([], tokens)
+    assert_exception_raised PARSER::Error, message do
+      PARSER.parse_key_value_param(
+        [[:string, "a"], [:invalid, ":"], [:string, "b"]]
+      )
     end
   end
 
   def test_parse
     text = "param_a, param_b, key_a: val_a, key_b: val_b, param_c, key_c: val_c"
-    params = ComfortableMexicanSofa::Content::ParamsParser.parse(text)
+    params = PARSER.parse(text)
     assert_equal [
       "param_a",
       "param_b",


### PR DESCRIPTION
* Makes the ParamsParser code a bit more readable.
* Adds type signatures to some content rendering types.

While figuring out how comfy's content rendering works, I spent most of the types following the code paths to figure out the types of things.

The next person won't have, as I've added the types in this PR.

Type signatures follow YARD (used by http://www.rubydoc.info/gems/comfortable_mexican_sofa) and have all been tested with the YARD parser at https://yardoc.org/types.