### PR TITLE
Allow Cms::BaseController to inherit from a custom base class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Gemfile.lock
 coverage/
 /storage
 db/cms_fixtures/test-site/
+.idea

--- a/app/controllers/comfy/cms/base_controller.rb
+++ b/app/controllers/comfy/cms/base_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Comfy::Cms::BaseController < ApplicationController
+class Comfy::Cms::BaseController < ComfortableMexicanSofa.config.base_cms_controller.to_s.constantize
 
   before_action :load_cms_site
 

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -7,6 +7,9 @@ ComfortableMexicanSofa.configure do |config|
   # Controller that is inherited from CmsAdmin::BaseController
   #   config.base_controller = 'ApplicationController'
 
+  # Controller that Comfy::Cms::BaseController will inherit from
+  #   config.base_cms_controller = 'ApplicationController'
+
   # Module responsible for authentication. You can replace it with your own.
   # It simply needs to have #authenticate method. See http_auth.rb for reference.
   #   config.admin_auth = 'ComfyAdminAuthentication'

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -9,6 +9,10 @@ class ComfortableMexicanSofa::Configuration
   # 'ApplicationController' is the default
   attr_accessor :base_controller
 
+  # Controller that Comfy::Cms::BaseController will inherit from
+  # 'ApplicationController' is the default
+  attr_accessor :base_cms_controller
+
   # Module that will handle authentication to access cms-admin area
   attr_accessor :admin_auth
 
@@ -80,6 +84,7 @@ class ComfortableMexicanSofa::Configuration
   def initialize
     @cms_title            = "ComfortableMexicanSofa CMS Engine"
     @base_controller      = "ApplicationController"
+    @base_cms_controller  = "ApplicationController"
     @admin_auth           = "ComfortableMexicanSofa::AccessControl::AdminAuthentication"
     @admin_authorization  = "ComfortableMexicanSofa::AccessControl::AdminAuthorization"
     @public_auth          = "ComfortableMexicanSofa::AccessControl::PublicAuthentication"

--- a/test/controllers/comfy/cms/base_controller_test.rb
+++ b/test/controllers/comfy/cms/base_controller_test.rb
@@ -19,7 +19,7 @@ class Comfy::Cms::BaseControllerTest < ActionDispatch::IntegrationTest
 
   def test_base_class_configuration
     get comfy_cms_render_page_path(cms_path: "")
-    assert @controller.kind_of? AnotherTestController
+    assert @controller.is_a? AnotherTestController
   end
 
 end

--- a/test/controllers/comfy/cms/base_controller_test.rb
+++ b/test/controllers/comfy/cms/base_controller_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "../../../test_helper"
+
+class AnotherTestController < ApplicationController; end
+
+class Comfy::Cms::BaseControllerTest < ActionDispatch::IntegrationTest
+
+  reset
+
+  setup do
+    @existing = ComfortableMexicanSofa.configuration.base_cms_controller
+    ComfortableMexicanSofa.configuration.base_cms_controller = "AnotherTestController"
+  end
+
+  teardown do
+    ComfortableMexicanSofa.configuration.base_cms_controller = @existing
+  end
+
+  def test_base_class_configuration
+    get comfy_cms_render_page_path(cms_path: "")
+    assert @controller.kind_of? AnotherTestController
+  end
+
+end

--- a/test/lib/configuration_test.rb
+++ b/test/lib/configuration_test.rb
@@ -8,6 +8,7 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert config = ComfortableMexicanSofa.configuration
     assert_equal "ComfortableMexicanSofa CMS Engine", config.cms_title
     assert_equal "ApplicationController", config.base_controller
+    assert_equal "ApplicationController", config.base_cms_controller
     assert_equal "ComfortableMexicanSofa::AccessControl::AdminAuthentication",  config.admin_auth
     assert_equal "ComfortableMexicanSofa::AccessControl::AdminAuthorization",   config.admin_authorization
     assert_equal "ComfortableMexicanSofa::AccessControl::PublicAuthentication", config.public_auth


### PR DESCRIPTION
### Summary

This PR simply replicates the existing behaviour in configuration that allows the end user to specify a custom base class for the `Admin::BaseController`, to the `Cms::BaseController`, instead of hardcoding it to inherit from `ApplicationController`

