### PR TITLE
Import and export seeds by class

### DIFF
--- a/lib/comfortable_mexican_sofa/seeds.rb
+++ b/lib/comfortable_mexican_sofa/seeds.rb
@@ -26,7 +26,7 @@ module ComfortableMexicanSofa::Seeds
       end
     end
 
-    def import!(klasses)
+    def import!(klasses = nil)
       klasses = klasses || %w[Layout Page Snippet File]
       klasses.each do |klass|
         klass = "ComfortableMexicanSofa::Seeds::#{klass}::Importer"
@@ -79,7 +79,7 @@ module ComfortableMexicanSofa::Seeds
       self.site = Comfy::Cms::Site.where(identifier: from).first!
     end
 
-    def export!(klasses)
+    def export!(klasses = nil)
       klasses = klasses || %w[Layout Page Snippet File]
       klasses.each do |klass|
         klass = "ComfortableMexicanSofa::Seeds::#{klass}::Exporter"

--- a/lib/comfortable_mexican_sofa/seeds.rb
+++ b/lib/comfortable_mexican_sofa/seeds.rb
@@ -26,8 +26,9 @@ module ComfortableMexicanSofa::Seeds
       end
     end
 
-    def import!
-      %w[Layout Page Snippet File].each do |klass|
+    def import!(klasses)
+      klasses = klasses || %w[Layout Page Snippet File]
+      klasses.each do |klass|
         klass = "ComfortableMexicanSofa::Seeds::#{klass}::Importer"
         klass.constantize.new(from, to).import!
       end
@@ -78,8 +79,9 @@ module ComfortableMexicanSofa::Seeds
       self.site = Comfy::Cms::Site.where(identifier: from).first!
     end
 
-    def export!
-      %w[Layout Page Snippet File].each do |klass|
+    def export!(klasses)
+      klasses = klasses || %w[Layout Page Snippet File]
+      klasses.each do |klass|
         klass = "ComfortableMexicanSofa::Seeds::#{klass}::Exporter"
         klass.constantize.new(from, to).export!
       end

--- a/lib/tasks/cms_seeds.rake
+++ b/lib/tasks/cms_seeds.rake
@@ -2,11 +2,12 @@
 
 namespace :comfy do
   namespace :cms_seeds do
-    desc "Import CMS Seed data into database (from: folder name, to: site identifier)"
+    desc "Import CMS Seed data into database (from: folder name, to: site identifier, klasses: class name[s])"
 
-    task :import, %i[from to] => [:environment] do |_t, args|
+    task :import, %i[from to klasses] => [:environment] do |_t, args|
       from  = args[:from]
       to    = args[:to] || from
+      klasses = args[:klasses].nil? ? nil : args[:klasses].split
 
       puts "Importing CMS Seed data from Folder [#{from}] to Site [#{to}] ..."
 
@@ -14,15 +15,16 @@ namespace :comfy do
       logger = ComfortableMexicanSofa.logger
       ComfortableMexicanSofa.logger = Logger.new(STDOUT)
 
-      ComfortableMexicanSofa::Seeds::Importer.new(from, to).import!
+      ComfortableMexicanSofa::Seeds::Importer.new(from, to).import!(klasses)
 
       ComfortableMexicanSofa.logger = logger
     end
 
-    desc "Export database data into CMS Seed files (from: site identifier, to: folder name)"
-    task :export, %i[from to] => [:environment] do |_t, args|
+    desc "Export database data into CMS Seed files (from: site identifier, to: folder name, klasses: class name[s])"
+    task :export, %i[from to klasses] => [:environment] do |_t, args|
       from  = args[:from]
       to    = args[:to] || from
+      klasses = args[:klasses].nil? ? nil : args[:klasses].split
 
       puts "Exporting CMS data from Site [#{from}] to Folder [#{to}] ..."
 
@@ -30,7 +32,7 @@ namespace :comfy do
       logger = ComfortableMexicanSofa.logger
       ComfortableMexicanSofa.logger = Logger.new(STDOUT)
 
-      ComfortableMexicanSofa::Seeds::Exporter.new(from, to).export!
+      ComfortableMexicanSofa::Seeds::Exporter.new(from, to).export!(klasses)
 
       ComfortableMexicanSofa.logger = logger
     end

--- a/test/lib/seeds_test.rb
+++ b/test/lib/seeds_test.rb
@@ -26,6 +26,34 @@ class SeedsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_import_single_class
+    Comfy::Cms::Page.destroy_all
+    Comfy::Cms::Layout.destroy_all
+    Comfy::Cms::Snippet.destroy_all
+
+    assert_difference(-> { Comfy::Cms::Layout.count }, 2) do
+      assert_difference(-> { Comfy::Cms::Page.count }, 0) do
+        assert_difference(-> { Comfy::Cms::Snippet.count }, 0) do
+          ComfortableMexicanSofa::Seeds::Importer.new("sample-site", "default-site").import!(["Layout"])
+        end
+      end
+    end
+  end
+
+  def test_import_multiple_classes
+    Comfy::Cms::Page.destroy_all
+    Comfy::Cms::Layout.destroy_all
+    Comfy::Cms::Snippet.destroy_all
+
+    assert_difference(-> { Comfy::Cms::Layout.count }, 2) do
+      assert_difference(-> { Comfy::Cms::Page.count }, 0) do
+        assert_difference(-> { Comfy::Cms::Snippet.count }, 1) do
+          ComfortableMexicanSofa::Seeds::Importer.new("sample-site", "default-site").import!(%w[Layout Snippet])
+        end
+      end
+    end
+  end
+
   def test_import_all_with_no_folder
     assert_exception_raised ComfortableMexicanSofa::Seeds::Error do
       ComfortableMexicanSofa::Seeds::Importer.new("invalid", "default-site").import!
@@ -48,6 +76,20 @@ class SeedsTest < ActiveSupport::TestCase
     assert_exception_raised ActiveRecord::RecordNotFound do
       ComfortableMexicanSofa::Seeds::Exporter.new("sample-site", "default-site").export!
     end
+  end
+
+  def test_export_single_class
+    host_path = File.join(ComfortableMexicanSofa.config.seeds_path, "test-site")
+    ComfortableMexicanSofa::Seeds::Exporter.new("default-site", "test-site").export!(["Layout"])
+    assert(File.exist?(File.join(host_path, "layouts")))
+    FileUtils.rm_rf(host_path)
+  end
+
+  def test_export_multiple_classes
+    host_path = File.join(ComfortableMexicanSofa.config.seeds_path, "test-site")
+    ComfortableMexicanSofa::Seeds::Exporter.new("default-site", "test-site").export!(%w[Layout Snippet])
+    assert(%w[layouts snippets].all? {|klass| File.exist?(File.join(host_path, klass))})
+    FileUtils.rm_rf(host_path)
   end
 
 end


### PR DESCRIPTION
Resolves issue #838 by extending `ComfortableMexicanSofa::Seeds::Importer.import!` and `ComfortableMexicanSofa::Seeds::Exporter.export!`, as well as `comfy:cms_seeds:import` and `comfy:cms_seeds:export` tasks, to accept optional array of class names to import or export—respectively—instead of all class names (default).