### PR TITLE
Add precompiled assets explicitly

### DIFF
--- a/lib/comfortable_mexican_sofa/engine.rb
+++ b/lib/comfortable_mexican_sofa/engine.rb
@@ -13,6 +13,14 @@ require "sass-rails"
 module ComfortableMexicanSofa
   class Engine < ::Rails::Engine
 
+    initializer 'rails_email_preview.setup_assets' do
+      ::ComfortableMexicanSofa::Engine.config.assets.precompile += %w(
+        comfy/admin/cms/application.js
+        comfy/admin/cms/application.css
+        comfy/admin/cms/lib/redactor-font.eot
+      )
+    end
+    
     config.to_prepare do
       Dir.glob(Rails.root + "app/decorators/comfortable_mexican_sofa/*_decorator*.rb").each do |c|
         require_dependency(c)

--- a/lib/comfortable_mexican_sofa/engine.rb
+++ b/lib/comfortable_mexican_sofa/engine.rb
@@ -13,7 +13,7 @@ require "sass-rails"
 module ComfortableMexicanSofa
   class Engine < ::Rails::Engine
 
-    initializer 'comfortable_mexican_sofa.setup_assets' do
+    initializer "comfortable_mexican_sofa.setup_assets" do
       ::ComfortableMexicanSofa::Engine.config.assets.precompile += %w[
         comfy/admin/cms/application.js
         comfy/admin/cms/application.css

--- a/lib/comfortable_mexican_sofa/engine.rb
+++ b/lib/comfortable_mexican_sofa/engine.rb
@@ -14,11 +14,11 @@ module ComfortableMexicanSofa
   class Engine < ::Rails::Engine
 
     initializer 'comfortable_mexican_sofa.setup_assets' do
-      ::ComfortableMexicanSofa::Engine.config.assets.precompile += %w(
+      ::ComfortableMexicanSofa::Engine.config.assets.precompile += %w[
         comfy/admin/cms/application.js
         comfy/admin/cms/application.css
         comfy/admin/cms/lib/redactor-font.eot
-      )
+      ]
     end
     
     config.to_prepare do

--- a/lib/comfortable_mexican_sofa/engine.rb
+++ b/lib/comfortable_mexican_sofa/engine.rb
@@ -20,7 +20,7 @@ module ComfortableMexicanSofa
         comfy/admin/cms/lib/redactor-font.eot
       ]
     end
-    
+
     config.to_prepare do
       Dir.glob(Rails.root + "app/decorators/comfortable_mexican_sofa/*_decorator*.rb").each do |c|
         require_dependency(c)

--- a/lib/comfortable_mexican_sofa/engine.rb
+++ b/lib/comfortable_mexican_sofa/engine.rb
@@ -13,7 +13,7 @@ require "sass-rails"
 module ComfortableMexicanSofa
   class Engine < ::Rails::Engine
 
-    initializer 'rails_email_preview.setup_assets' do
+    initializer 'comfortable_mexican_sofa.setup_assets' do
       ::ComfortableMexicanSofa::Engine.config.assets.precompile += %w(
         comfy/admin/cms/application.js
         comfy/admin/cms/application.css


### PR DESCRIPTION
This should be explicit because:

a) The user may override the default `config.assets.precompile`, removing a default `/application\.(css|js)/` entry.

b) The user may also be using Sprockets 4, which only has `manifest.js` in `config.assets.precompile` by default. Not sure if this alone is enough for Sprockets 4 compatibility though.