### PR TITLE
Preserve order of categorized items

### DIFF
--- a/app/models/comfy/cms/page.rb
+++ b/app/models/comfy/cms/page.rb
@@ -7,7 +7,7 @@ class Comfy::Cms::Page < ActiveRecord::Base
   include Comfy::Cms::WithFragments
   include Comfy::Cms::WithCategories
 
-  cms_acts_as_tree counter_cache: :children_count
+  cms_acts_as_tree counter_cache: :children_count, order: :position
   cms_has_revisions_for :fragments_attributes
 
   # -- Relationships -----------------------------------------------------------


### PR DESCRIPTION
This patch explicitly orders categorized lists by their position stored in the database.

Apparently this behaviour got lost somewhere in the transition to CMS 2.0.
