### PR TITLE
Strip newlines/whitespace from fragment before processing mime_type

### DIFF
--- a/app/controllers/comfy/cms/content_controller.rb
+++ b/app/controllers/comfy/cms/content_controller.rb
@@ -44,7 +44,7 @@ protected
   # it's possible to control mimetype of a page by creating a `mime_type` field
   def mime_type
     mime_block = @cms_page.fragments.detect { |f| f.identifier == "mime_type" }
-    mime_block&.content || "text/html"
+    mime_block&.content&.strip || "text/html"
   end
 
   def app_layout


### PR DESCRIPTION
Due to the new seed format, even single-lined text fields can contain newlines after importing.
This may confuse Rails into sending multiple Content-Type headers, and won't work as expected.

Simple solution: Strip whitespaces from the mime_type fragment.
