### PR TITLE
Render form elements from included elements

### DIFF
--- a/app/models/concerns/comfy/cms/with_fragments.rb
+++ b/app/models/concerns/comfy/cms/with_fragments.rb
@@ -78,6 +78,8 @@ module Comfy::Cms::WithFragments
   # duplicate tags on the layout. That's wierd (but still works).
   def fragment_nodes
     nodes
+      .map { |n| n.respond_to?(:nodes) ? ([n] + n.nodes) : n }
+      .flatten
       .select { |n| n.is_a?(ComfortableMexicanSofa::Content::Tag::Fragment) }
       .uniq(&:identifier)
   end


### PR DESCRIPTION
Allow rendering admin form elements from included content, snippets etc.
This functionality apparently was lost in the transition to Comfy 2.0