### PR TITLE
Add option to customize the returned Content JSON data

### DIFF
--- a/app/controllers/comfy/cms/content_controller.rb
+++ b/app/controllers/comfy/cms/content_controller.rb
@@ -21,7 +21,8 @@ class Comfy::Cms::ContentController < Comfy::Cms::BaseController
       respond_to do |format|
         format.html { render_page }
         format.json do
-          json_page = @cms_page.as_json(except: [:content_cache])
+          json_options = {except: [:content_cache]}.merge(ComfortableMexicanSofa.config.content_json_options)
+          json_page = @cms_page.as_json(json_options)
           json_page[:content] = render_to_string(
             inline: @cms_page.content_cache,
             layout: false

--- a/app/controllers/comfy/cms/content_controller.rb
+++ b/app/controllers/comfy/cms/content_controller.rb
@@ -21,7 +21,7 @@ class Comfy::Cms::ContentController < Comfy::Cms::BaseController
       respond_to do |format|
         format.html { render_page }
         format.json do
-          json_options = {except: [:content_cache]}.merge(ComfortableMexicanSofa.config.content_json_options)
+          json_options = { except: [:content_cache] }.merge(ComfortableMexicanSofa.config.content_json_options)
           json_page = @cms_page.as_json(json_options)
           json_page[:content] = render_to_string(
             inline: @cms_page.content_cache,

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -80,6 +80,12 @@ ComfortableMexicanSofa.configure do |config|
   # Reveal partials that can be overwritten in the admin area.
   # Default is false.
   #   config.reveal_cms_partials = false
+  #
+  # Customize the returned content json data
+  # include fragments in content json
+  #   config.content_json_options = {
+  #     include: [:fragments]
+  #   }
 end
 
 # Default credentials for ComfortableMexicanSofa::AccessControl::AdminAuthentication

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -80,6 +80,8 @@ class ComfortableMexicanSofa::Configuration
   # Auto-setting parameter derived from the routes
   attr_accessor :public_cms_path
 
+  attr_accessor :content_json_options
+
   # Configuration defaults
   def initialize
     @cms_title              = "ComfortableMexicanSofa CMS Engine"
@@ -127,6 +129,8 @@ class ComfortableMexicanSofa::Configuration
     @hostname_aliases     = nil
     @reveal_cms_partials  = false
     @public_cms_path      = nil
+    @content_json_options = {}
+
   end
 
 end

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -132,7 +132,6 @@ class ComfortableMexicanSofa::Configuration
     @reveal_cms_partials  = false
     @public_cms_path      = nil
     @content_json_options = {}
-
   end
 
 end

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -80,6 +80,8 @@ class ComfortableMexicanSofa::Configuration
   # Auto-setting parameter derived from the routes
   attr_accessor :public_cms_path
 
+  # Customize returned content json data
+  # e.g. include fragments into json data config.content_json_options = { include: [:fragments] }
   attr_accessor :content_json_options
 
   # Configuration defaults

--- a/test/controllers/comfy/cms/content_controller_json_test.rb
+++ b/test/controllers/comfy/cms/content_controller_json_test.rb
@@ -41,7 +41,7 @@ class Comfy::Cms::ContentControllerJsonTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal "application/json", response.content_type
     json_response = JSON.parse(response.body)
-    puts json_response
+
     assert_equal @page.id,        json_response["id"]
     assert_equal @page.site.id,   json_response["site_id"]
     assert_equal @page.layout.id, json_response["layout_id"]

--- a/test/controllers/comfy/cms/content_controller_json_test.rb
+++ b/test/controllers/comfy/cms/content_controller_json_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require_relative "../../../test_helper"
+
+class Comfy::Cms::ContentControllerJsonTest < ActionDispatch::IntegrationTest
+
+  setup do
+    @site         = comfy_cms_sites(:default)
+    @layout       = comfy_cms_layouts(:default)
+    @page         = comfy_cms_pages(:default)
+    @translation  = comfy_cms_translations(:default)
+  end
+
+  def test_show_as_json
+    setup_json_config({})
+    get comfy_cms_render_page_path(cms_path: ""), as: :json
+    assert_response :success
+    assert_equal "application/json", response.content_type
+
+    json_response = JSON.parse(response.body)
+    assert_equal @page.id,        json_response["id"]
+    assert_equal @page.site.id,   json_response["site_id"]
+    assert_equal @page.layout.id, json_response["layout_id"]
+    assert_nil                    json_response["parent_id"]
+    assert_nil                    json_response["target_page_id"]
+    assert_equal "Default Page",  json_response["label"]
+    assert_nil                    json_response["slug"]
+    assert_equal "/",             json_response["full_path"]
+    assert_equal "content",       json_response["content"]
+    assert_equal 0,               json_response["position"]
+    assert_equal 1,               json_response["children_count"]
+    assert_equal true,            json_response["is_published"]
+    assert_nil                    json_response["fragments"]
+  end
+
+  def test_show_as_json_with_include
+    setup_json_config({
+      include: [:fragments]
+    })
+    get comfy_cms_render_page_path(cms_path: ""), as: :json
+    assert_response :success
+    assert_equal "application/json", response.content_type
+    json_response = JSON.parse(response.body)
+    puts json_response
+    assert_equal @page.id,        json_response["id"]
+    assert_equal @page.site.id,   json_response["site_id"]
+    assert_equal @page.layout.id, json_response["layout_id"]
+    assert_nil                    json_response["parent_id"]
+    assert_nil                    json_response["target_page_id"]
+    assert_equal "Default Page",  json_response["label"]
+    assert_nil                    json_response["slug"]
+    assert_equal "/",             json_response["full_path"]
+    assert_equal "content",       json_response["content"]
+    assert_equal 0,               json_response["position"]
+    assert_equal 1,               json_response["children_count"]
+    assert_equal true,            json_response["is_published"]
+    assert_equal 4,               json_response["fragments"].length
+  end
+
+  def setup_json_config(json_options = {})
+    ComfortableMexicanSofa.configure do |config|
+      config.cms_title            = "ComfortableMexicanSofa CMS Engine"
+      config.admin_auth           = "ComfortableMexicanSofa::AccessControl::AdminAuthentication"
+      config.admin_authorization  = "ComfortableMexicanSofa::AccessControl::AdminAuthorization"
+      config.public_auth          = "ComfortableMexicanSofa::AccessControl::PublicAuthentication"
+      config.public_authorization = "ComfortableMexicanSofa::AccessControl::PublicAuthorization"
+      config.admin_route_redirect = ""
+      config.enable_seeds         = false
+      config.seeds_path           = File.expand_path("db/cms_seeds", Rails.root)
+      config.revisions_limit      = 25
+      config.locales              = {
+        "en" => "English",
+        "es" => "Español"
+      }
+      config.admin_locale         = nil
+      config.admin_cache_sweeper  = nil
+      config.allow_erb            = false
+      config.allowed_helpers      = nil
+      config.allowed_partials     = nil
+      config.allowed_templates    = nil
+      config.hostname_aliases     = nil
+      config.reveal_cms_partials  = false
+      config.public_cms_path      = nil
+      config.content_json_options = json_options
+    end
+  end
+end

--- a/test/controllers/comfy/cms/content_controller_json_test.rb
+++ b/test/controllers/comfy/cms/content_controller_json_test.rb
@@ -34,9 +34,9 @@ class Comfy::Cms::ContentControllerJsonTest < ActionDispatch::IntegrationTest
   end
 
   def test_show_as_json_with_include
-    setup_json_config({
+    setup_json_config(
       include: [:fragments]
-    })
+    )
     get comfy_cms_render_page_path(cms_path: ""), as: :json
     assert_response :success
     assert_equal "application/json", response.content_type
@@ -84,4 +84,5 @@ class Comfy::Cms::ContentControllerJsonTest < ActionDispatch::IntegrationTest
       config.content_json_options = json_options
     end
   end
+
 end

--- a/test/lib/configuration_test.rb
+++ b/test/lib/configuration_test.rb
@@ -27,7 +27,6 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_nil config.allowed_partials
     assert_nil config.allowed_templates
     assert_nil config.hostname_aliases
-    assert_equal({}, config.content_json_options)
   end
 
   def test_initialization_overrides

--- a/test/lib/configuration_test.rb
+++ b/test/lib/configuration_test.rb
@@ -27,6 +27,7 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_nil config.allowed_partials
     assert_nil config.allowed_templates
     assert_nil config.hostname_aliases
+    assert_equal({}, config.content_json_options)
   end
 
   def test_initialization_overrides


### PR DESCRIPTION
### Add option to customize the returned Content JSON data

This PR will add an option for dev to customize the content JSON data. 

This will enable JS-Client (e.g. React, VueJS apps) to use the page fragments and custom display it on client apps.

