### PR TITLE
Sass -> SassC

### DIFF
--- a/comfortable_mexican_sofa.gemspec
+++ b/comfortable_mexican_sofa.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.add_dependency "mini_magick",           ">= 4.8.0"
   s.add_dependency "rails",                 ">= 5.2.0"
   s.add_dependency "rails-i18n",            ">= 5.0.0"
-  s.add_dependency "sass-rails",            ">= 5.0.0"
+  s.add_dependency "sassc-rails",           ">= 2.0.0"
 end

--- a/lib/comfortable_mexican_sofa/engine.rb
+++ b/lib/comfortable_mexican_sofa/engine.rb
@@ -8,7 +8,7 @@ require "active_link_to"
 require "kramdown"
 require "jquery-rails"
 require "haml-rails"
-require "sass-rails"
+require "sassc-rails"
 
 module ComfortableMexicanSofa
   class Engine < ::Rails::Engine


### PR DESCRIPTION
The Ruby version of Sass is deprecated, see http://sass.logdown.com/posts/7081811