### PR TITLE
Fixes  "Update" and "Preview" buttons becoming 

### DIFF
--- a/app/views/comfy/admin/cms/pages/_form.html.haml
+++ b/app/views/comfy/admin/cms/pages/_form.html.haml
@@ -26,6 +26,6 @@
 = comfy_admin_partial "comfy/admin/cms/partials/page_form_after", form: form
 
 = form.form_actions do
-  = submit_tag t(".preview"), name: "preview", formtarget: "comfy-cms-preview", id: nil, class: "btn btn-secondary", data: {disable_with: false}
-  = submit_tag t(@page.new_record?? ".create" : ".update"), class: "btn btn-primary ml-sm-1", data: {disable_with: false}
+  = submit_tag t(".preview"), name: "preview", formtarget: "comfy-cms-preview", id: nil, class: "btn btn-secondary"
+  = submit_tag t(@page.new_record?? ".create" : ".update"), class: "btn btn-primary ml-sm-1"
   = link_to t(".cancel"), comfy_admin_cms_site_pages_path, class: "btn btn-link"


### PR DESCRIPTION
### Summary

When using the preview button editing a page, the Update and Preview buttons have their text changed to "false" and become disabled. The data-disable-with
attribute was set to false.  Removing the data-disable-with attribute maintains
the text and functionality of the buttons.

Fixes #856 