### PR TITLE
Allow html class in file content

### DIFF
--- a/lib/comfortable_mexican_sofa/content/tags/file.rb
+++ b/lib/comfortable_mexican_sofa/content/tags/file.rb
@@ -11,6 +11,7 @@ require_relative "./mixins/file_content"
 # `resize`  - imagemagic option. For example: "100x50>"
 # `gravity` - imagemagic option. For example: "center"
 # `crop`    - imagemagic option. For example: "100x50+0+0"
+# `class`   - any html classes that you want on the result link or image tag. For example "class1 class2"
 #
 class ComfortableMexicanSofa::Content::Tag::File < ComfortableMexicanSofa::Content::Tag::Fragment
 
@@ -27,7 +28,7 @@ class ComfortableMexicanSofa::Content::Tag::File < ComfortableMexicanSofa::Conte
     super
     @as             = options["as"] || "url"
     @label          = options["label"]
-    @variant_attrs  = options.slice("resize", "gravity", "crop")
+    @variant_attrs  = options.slice("resize", "gravity", "crop", "class")
   end
 
   def form_field(object_name, view, index)

--- a/lib/comfortable_mexican_sofa/content/tags/file_link.rb
+++ b/lib/comfortable_mexican_sofa/content/tags/file_link.rb
@@ -11,6 +11,7 @@ require_relative "./mixins/file_content"
 # `resize`  - imagemagic option. For example: "100x50>"
 # `gravity` - imagemagic option. For example: "center"
 # `crop`    - imagemagic option. For example: "100x50+0+0"
+# `class`   - any html classes that you want on the result link or image tag. For example "class1 class2"
 #
 class ComfortableMexicanSofa::Content::Tag::FileLink < ComfortableMexicanSofa::Content::Tag
 
@@ -31,7 +32,7 @@ class ComfortableMexicanSofa::Content::Tag::FileLink < ComfortableMexicanSofa::C
     options = params.extract_options!
     @identifier     = params[0]
     @as             = options["as"] || "url"
-    @variant_attrs  = options.slice("resize", "gravity", "crop")
+    @variant_attrs  = options.slice("resize", "gravity", "crop", "class")
 
     unless @identifier.present?
       raise Error, "Missing identifier for file link tag"

--- a/lib/comfortable_mexican_sofa/content/tags/mixins/file_content.rb
+++ b/lib/comfortable_mexican_sofa/content/tags/mixins/file_content.rb
@@ -29,7 +29,7 @@ module ComfortableMexicanSofa::Content::Tag::Mixins
     end
 
     def html_class
-      variant_attrs["class"].blank?? "" : " class='#{variant_attrs["class"]}'"
+      variant_attrs["class"].blank? ? "" : " class='#{variant_attrs['class']}'"
     end
 
     # @param [ActiveStorage::Blob]

--- a/lib/comfortable_mexican_sofa/content/tags/mixins/file_content.rb
+++ b/lib/comfortable_mexican_sofa/content/tags/mixins/file_content.rb
@@ -12,7 +12,7 @@ module ComfortableMexicanSofa::Content::Tag::Mixins
     def content(file: self.file, as: self.as, variant_attrs: self.variant_attrs, label: self.label)
       return "" unless file
 
-      if variant_attrs.present? && file.image?
+      if variant_attrs.except("class").present? && file.image?
         file = file.variant(combine_options: variant_attrs)
       end
 
@@ -20,12 +20,16 @@ module ComfortableMexicanSofa::Content::Tag::Mixins
 
       case as
       when "link"
-        "<a href='#{url}' target='_blank'>#{label}</a>"
+        "<a href='#{url}' target='_blank'#{html_class}>#{label}</a>"
       when "image"
-        "<img src='#{url}' alt='#{label}'/>"
+        "<img src='#{url}' alt='#{label}'#{html_class}/>"
       else
         url
       end
+    end
+
+    def html_class
+      variant_attrs["class"].blank?? "" : " class='#{variant_attrs["class"]}'"
     end
 
     # @param [ActiveStorage::Blob]

--- a/lib/comfortable_mexican_sofa/content/tags/page_file_link.rb
+++ b/lib/comfortable_mexican_sofa/content/tags/page_file_link.rb
@@ -20,6 +20,7 @@ require_relative "./mixins/file_content"
 # `resize`  - imagemagick option. For example: "100x50>"
 # `gravity` - imagemagick option. For example: "center"
 # `crop`    - imagemagick option. For example: "100x50+0+0"
+# `class`   - any html classes that you want on the result link or image tag. For example "class1 class2"
 #
 class ComfortableMexicanSofa::Content::Tag::PageFileLink < ComfortableMexicanSofa::Content::Tag
 
@@ -44,7 +45,7 @@ class ComfortableMexicanSofa::Content::Tag::PageFileLink < ComfortableMexicanSof
     options = params.extract_options!
     @identifier     = params[0]
     @as             = options["as"] || "url"
-    @variant_attrs  = options.slice("resize", "gravity", "crop")
+    @variant_attrs  = options.slice("resize", "gravity", "crop", "class")
     @filename       = options["filename"]
 
     unless @identifier.present?

--- a/test/lib/content/tags/file_link_test.rb
+++ b/test/lib/content/tags/file_link_test.rb
@@ -27,7 +27,8 @@ class ContentTagsFileLinkTest < ActiveSupport::TestCase
           "as"      => "image",
           "resize"  => "100x100",
           "gravity" => "center",
-          "crop"    => "100x100+0+0"
+          "crop"    => "100x100+0+0",
+          "class"   => "class1 class2"
         }
       ]
     )
@@ -36,7 +37,8 @@ class ContentTagsFileLinkTest < ActiveSupport::TestCase
     assert_equal ({
       "resize"  => "100x100",
       "gravity" => "center",
-      "crop"    => "100x100+0+0"
+      "crop"    => "100x100+0+0",
+      "class"   => "class1 class2"
     }), tag.variant_attrs
   end
 
@@ -65,10 +67,10 @@ class ContentTagsFileLinkTest < ActiveSupport::TestCase
   def test_content_as_link
     tag = ComfortableMexicanSofa::Content::Tag::FileLink.new(
       context: @page,
-      params: [@file.id, { "as" => "link" }]
+      params: [@file.id, { "as" => "link", "class" => "class1" }]
     )
     url = rails_blob_path(tag.file, only_path: true)
-    out = "<a href='#{url}' target='_blank'>default file</a>"
+    out = "<a href='#{url}' target='_blank' class='class1'>default file</a>"
     assert_equal out, tag.content
     assert_equal out, tag.render
   end


### PR DESCRIPTION
### Summary

Fixes #855 Is it possible to add html class for image?. by adding a new variant attribute "class" which is simply passed through to the img/a tag that is generated. Simply,
` {{ cms:file_link 612, as: image class='class1 class2' }}`

- added test
- rake green.
- updated docs
