### PR TITLE
Fix indentation for first page navigation

### DIFF
--- a/app/views/kaminari/comfy/_first_page.html.haml
+++ b/app/views/kaminari/comfy/_first_page.html.haml
@@ -1,3 +1,3 @@
 - unless current_page.first?
   %li.page-item
-  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, class: 'page-link', remote: remote
+    = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, class: 'page-link', remote: remote


### PR DESCRIPTION
### The first page navigation layout is broken due to indentation

I just noticed this while developing a website using Comfy and is breaking the layout. Small indentation fix.

Thank you for the amazing engine 😄 