### PR TITLE
[Fix] Add font-style edit fix to 1.12

### DIFF
--- a/app/assets/javascripts/comfy/admin/cms/lib/redactor.js
+++ b/app/assets/javascripts/comfy/admin/cms/lib/redactor.js
@@ -7729,6 +7729,10 @@
 					{
 						var node2 = this.selection.getMarker(2);
 						this.selection.setMarker(this.range, node2, false);
+
+						// COMFY FIX
+						if (this.utils.browser('chrome')) this.caret.set(node1, 0, node2, 0);
+						// END COMFY FIX
 					}
 
 					this.savedSel = this.$editor.html();


### PR DESCRIPTION
### Summary

Apply font-style editing fix for Redactor. This change has already been applied to v2 but is not yet available for v1.

Closes #866