### PR TITLE
Update label in db when process attaching the file

### DIFF
--- a/app/models/comfy/cms/file.rb
+++ b/app/models/comfy/cms/file.rb
@@ -51,6 +51,7 @@ protected
   def process_attachment
     return if @file.blank?
     attachment.attach(@file)
+    update_attribute(:label, label)
   end
 
 end


### PR DESCRIPTION
Problem was that when uploading a new file the actual
label would be empty. Model will return a label when
requested as it will read the file name if label is
empty, but when doing in rails helpers something like

Comfy::Cms::File.where(label: "name")

the file will not be found.

This fix will call update_attribute on the label
after the file is save in controller and the actual
file is attached to the model, simple enough.


Signed-off-by: oscar sanhueza <oscar@hashdot.fi>

### Summary

General information about what this PR is all about. If it fixes any issues
please don't forget to tag them.

Thanks for contributing!
