### PR TITLE
Write label attribute before save using filename

### DIFF
--- a/app/models/comfy/cms/file.rb
+++ b/app/models/comfy/cms/file.rb
@@ -22,6 +22,7 @@ class Comfy::Cms::File < ActiveRecord::Base
 
   # -- Callbacks ---------------------------------------------------------------
   before_create :assign_position
+  before_save :assing_label_name
   after_save :process_attachment
 
   # -- Validations -------------------------------------------------------------
@@ -46,6 +47,11 @@ protected
   def assign_position
     max = Comfy::Cms::File.maximum(:position)
     self.position = max ? max + 1 : 0
+  end
+
+  def assing_label_name
+    l = read_attribute(:label)
+    write_attribute(:label, file.original_filename) unless l.present?
   end
 
   def process_attachment


### PR DESCRIPTION
Problem was that when uploading a new file the actual
label would be empty. Model will return a label when
requested as it will read the file name if label is
empty, but when doing in rails helpers something like

Comfy::Cms::File.where(label: "name")

the file will not be found.

This fix will user before_save callback to write
the label attribute on the model using the file name
which will be saved then in DB


Signed-off-by: oscar sanhueza <oscar@hashdot.fi>

### Summary

General information about what this PR is all about. If it fixes any issues
please don't forget to tag them.

Thanks for contributing!
