### PR TITLE
Write label attribute before save using filename

### DIFF
--- a/app/models/comfy/cms/file.rb
+++ b/app/models/comfy/cms/file.rb
@@ -22,7 +22,7 @@ class Comfy::Cms::File < ActiveRecord::Base
 
   # -- Callbacks ---------------------------------------------------------------
   before_create :assign_position
-  before_save :assing_label_name
+  before_save :assign_label_name
   after_save :process_attachment
 
   # -- Validations -------------------------------------------------------------
@@ -49,7 +49,7 @@ protected
     self.position = max ? max + 1 : 0
   end
 
-  def assing_label_name
+  def assign_label_name
     l = read_attribute(:label)
     write_attribute(:label, file.original_filename) unless l.present?
   end

--- a/app/models/comfy/cms/file.rb
+++ b/app/models/comfy/cms/file.rb
@@ -22,6 +22,7 @@ class Comfy::Cms::File < ActiveRecord::Base
 
   # -- Callbacks ---------------------------------------------------------------
   before_create :assign_position
+  before_save :assing_label_name
   after_save :process_attachment
 
   # -- Validations -------------------------------------------------------------
@@ -46,6 +47,11 @@ protected
   def assign_position
     max = Comfy::Cms::File.maximum(:position)
     self.position = max ? max + 1 : 0
+  end
+
+  def assing_label_name
+    l = read_attribute(:label)
+    write_attribute(:label, file.original_filename) unless l.present?
   end
 
   def process_attachment

--- a/test/models/file_test.rb
+++ b/test/models/file_test.rb
@@ -28,6 +28,17 @@ class CmsFileTest < ActiveSupport::TestCase
       assert_equal 1, file.position
     end
   end
+  
+  def test_creation_without_label
+    assert_difference ["Comfy::Cms::File.count", "ActiveStorage::Attachment.count"] do
+      file = comfy_cms_sites(:default).files.create(
+        description:  "test file",
+        file:         fixture_file_upload("files/image.jpg", "image/jpeg")
+      )
+      assert_equal 1, file.position
+      assert_equal file.label, "image.jpg"
+    end
+  end
 
   def test_scope_with_images
     assert_equal 1, Comfy::Cms::File.with_attached_attachment.with_images.count

--- a/test/models/file_test.rb
+++ b/test/models/file_test.rb
@@ -19,7 +19,6 @@ class CmsFileTest < ActiveSupport::TestCase
   end
 
   def test_creation
-    binding.pry
     assert_difference ["Comfy::Cms::File.count", "ActiveStorage::Attachment.count"] do
       file = comfy_cms_sites(:default).files.create(
         label:        "test",

--- a/test/models/file_test.rb
+++ b/test/models/file_test.rb
@@ -19,6 +19,7 @@ class CmsFileTest < ActiveSupport::TestCase
   end
 
   def test_creation
+    binding.pry
     assert_difference ["Comfy::Cms::File.count", "ActiveStorage::Attachment.count"] do
       file = comfy_cms_sites(:default).files.create(
         label:        "test",
@@ -28,7 +29,7 @@ class CmsFileTest < ActiveSupport::TestCase
       assert_equal 1, file.position
     end
   end
-  
+
   def test_creation_without_label
     assert_difference ["Comfy::Cms::File.count", "ActiveStorage::Attachment.count"] do
       file = comfy_cms_sites(:default).files.create(


### PR DESCRIPTION
Problem was that when uploading a new file the actual
label would be empty. Model will return a label when
requested as it will read the file name if label is
empty, but when doing in rails helpers something like

Comfy::Cms::File.where(label: "name")

the file will not be found.

This fix will user before_save callback to write
the label attribute on the model using the file name
which will be saved then in DB


Signed-off-by: oscar sanhueza <oscar@hashdot.fi>

### Summary

I made some fixes on the branch and update the pull request, buti wanted my commit to be
nice so I just force pushed the branch and make the pull request again,
