### PR TITLE
Variant repr fix

### DIFF
--- a/lib/comfortable_mexican_sofa/content/tags/mixins/file_content.rb
+++ b/lib/comfortable_mexican_sofa/content/tags/mixins/file_content.rb
@@ -16,7 +16,6 @@ module ComfortableMexicanSofa::Content::Tag::Mixins
         file = file.variant(combine_options: variant_attrs)
       end
 
-      #url = rails_blob_path(file.blob)
       url = file_path(file)
 
       case as
@@ -33,19 +32,12 @@ module ComfortableMexicanSofa::Content::Tag::Mixins
     # @return [String]
     def file_path file
       helper = Rails.application.routes.url_helpers
-      #if file.is_a?(ActiveStorage::Variant)
       if file.respond_to?(:variation)
         helper.rails_representation_path(file, only_path: true)
       else
         helper.rails_blob_path(file.blob, only_path: true)
       end
     end
-
-    # @param [ActiveStorage::Blob]
-    # @return [String]
-    #def rails_blob_path(blob)
-    #  Rails.application.routes.url_helpers.rails_blob_path(blob, only_path: true)
-    #end
 
   end
 end

--- a/lib/comfortable_mexican_sofa/content/tags/mixins/file_content.rb
+++ b/lib/comfortable_mexican_sofa/content/tags/mixins/file_content.rb
@@ -16,7 +16,8 @@ module ComfortableMexicanSofa::Content::Tag::Mixins
         file = file.variant(combine_options: variant_attrs)
       end
 
-      url = rails_blob_path(file.blob)
+      #url = rails_blob_path(file.blob)
+      url = file_path(file)
 
       case as
       when "link"
@@ -28,11 +29,23 @@ module ComfortableMexicanSofa::Content::Tag::Mixins
       end
     end
 
+    # @param [ActiveStorage::Attachment or ActiveStorage::Variant]
+    # @return [String]
+    def file_path file
+      helper = Rails.application.routes.url_helpers
+      #if file.is_a?(ActiveStorage::Variant)
+      if file.respond_to?(:variation)
+        helper.rails_representation_path(file, only_path: true)
+      else
+        helper.rails_blob_path(file.blob, only_path: true)
+      end
+    end
+
     # @param [ActiveStorage::Blob]
     # @return [String]
-    def rails_blob_path(blob)
-      Rails.application.routes.url_helpers.rails_blob_path(blob, only_path: true)
-    end
+    #def rails_blob_path(blob)
+    #  Rails.application.routes.url_helpers.rails_blob_path(blob, only_path: true)
+    #end
 
   end
 end


### PR DESCRIPTION
### Summary

Not sure from which rails version on this is needed, but to get the right path for the modified image rails_representation_path (or *_url) is to be used.
Thanks to https://www.20spokes.com/blog/using-active-storage-with-active-model-serializers/
Not very well documented elsewhere (at least in my filter-bubble).
Now, for example, when using the content-tag cms:file the url is correct with all (image-magick) processing options and the variant is shown on the page
