### PR TITLE
Fix default classes for comfy cms seeds import and export task

### DIFF
--- a/lib/comfortable_mexican_sofa/seeds.rb
+++ b/lib/comfortable_mexican_sofa/seeds.rb
@@ -2,13 +2,13 @@
 
 module ComfortableMexicanSofa::Seeds
 
-  SEED_CLASSES = %w[Layout Page Snippet File].freeze
-
   class Error < StandardError; end
 
   require "mimemagic"
 
   class Importer
+    
+    SEED_CLASSES = %w[Layout Page Snippet File].freeze
 
     attr_accessor :site,
                   :path,

--- a/lib/comfortable_mexican_sofa/seeds.rb
+++ b/lib/comfortable_mexican_sofa/seeds.rb
@@ -3,7 +3,7 @@
 module ComfortableMexicanSofa::Seeds
 
   SEED_CLASSES = %w[Layout Page Snippet File].freeze
-  
+
   class Error < StandardError; end
 
   require "mimemagic"

--- a/lib/comfortable_mexican_sofa/seeds.rb
+++ b/lib/comfortable_mexican_sofa/seeds.rb
@@ -2,13 +2,13 @@
 
 module ComfortableMexicanSofa::Seeds
 
+  SEED_CLASSES = %w[Layout Page Snippet File].freeze
+  
   class Error < StandardError; end
 
   require "mimemagic"
 
   class Importer
-    
-    SEED_CLASSES = %w[Layout Page Snippet File].freeze
 
     attr_accessor :site,
                   :path,
@@ -28,7 +28,7 @@ module ComfortableMexicanSofa::Seeds
       end
     end
 
-    def import!(classes = SEED_CLASSES)
+    def import!(classes = ComfortableMexicanSofa::Seeds::SEED_CLASSES)
       classes.each do |klass|
         klass = "ComfortableMexicanSofa::Seeds::#{klass}::Importer"
         klass.constantize.new(from, to).import!
@@ -80,7 +80,7 @@ module ComfortableMexicanSofa::Seeds
       self.site = Comfy::Cms::Site.where(identifier: from).first!
     end
 
-    def export!(classes = SEED_CLASSES)
+    def export!(classes = ComfortableMexicanSofa::Seeds::SEED_CLASSES)
       classes.each do |klass|
         klass = "ComfortableMexicanSofa::Seeds::#{klass}::Exporter"
         klass.constantize.new(from, to).export!

--- a/lib/comfortable_mexican_sofa/seeds.rb
+++ b/lib/comfortable_mexican_sofa/seeds.rb
@@ -28,7 +28,9 @@ module ComfortableMexicanSofa::Seeds
       end
     end
 
-    def import!(classes = ComfortableMexicanSofa::Seeds::SEED_CLASSES)
+    # if passed nil will use default seed classes
+    def import!(classes=nil)
+      classes ||= SEED_CLASSES
       classes.each do |klass|
         klass = "ComfortableMexicanSofa::Seeds::#{klass}::Importer"
         klass.constantize.new(from, to).import!
@@ -80,7 +82,9 @@ module ComfortableMexicanSofa::Seeds
       self.site = Comfy::Cms::Site.where(identifier: from).first!
     end
 
-    def export!(classes = ComfortableMexicanSofa::Seeds::SEED_CLASSES)
+    # if passed nil will use default seed classes
+    def export!(classes=nil)
+      classes ||= SEED_CLASSES
       classes.each do |klass|
         klass = "ComfortableMexicanSofa::Seeds::#{klass}::Exporter"
         klass.constantize.new(from, to).export!

--- a/lib/comfortable_mexican_sofa/seeds.rb
+++ b/lib/comfortable_mexican_sofa/seeds.rb
@@ -29,7 +29,7 @@ module ComfortableMexicanSofa::Seeds
     end
 
     # if passed nil will use default seed classes
-    def import!(classes=nil)
+    def import!(classes = nil)
       classes ||= SEED_CLASSES
       classes.each do |klass|
         klass = "ComfortableMexicanSofa::Seeds::#{klass}::Importer"
@@ -83,7 +83,7 @@ module ComfortableMexicanSofa::Seeds
     end
 
     # if passed nil will use default seed classes
-    def export!(classes=nil)
+    def export!(classes = nil)
       classes ||= SEED_CLASSES
       classes.each do |klass|
         klass = "ComfortableMexicanSofa::Seeds::#{klass}::Exporter"


### PR DESCRIPTION
### Summary

Currently the import and export tasks will pass nil as classes argument which causes failure.
Changed import and export to use nil as default argument and default to SEED_CLASSES on nil argument.

Note: My CI environment is currently offline, but import has been tested in console.
