### PR TITLE
Fixes error when returning nil from template

### DIFF
--- a/app/views/comfy/admin/cms/sites/_mirrors.html.haml
+++ b/app/views/comfy/admin/cms/sites/_mirrors.html.haml
@@ -1,18 +1,18 @@
-- return unless @site.is_mirrored?
+- if @site.is_mirrored?
 
-- object ||= nil
-  
-- options = case object
-  - when ::Comfy::Cms::Layout
-    - object.mirrors.collect{|m| [m.site.label, edit_comfy_admin_cms_site_layout_path(m.site, m)]}
-  - when ::Comfy::Cms::Page
-    - object.mirrors.collect{|m| [m.site.label, edit_comfy_admin_cms_site_page_path(m.site, m)]}
-  - when ::Comfy::Cms::Snippet
-    - object.mirrors.collect{|m| [m.site.label, edit_comfy_admin_cms_site_snippet_path(m.site, m)]}
-  - else
-    - (::Comfy::Cms::Site.mirrored - [@site]).collect{|s| [s.label, url_for(params.permit!.merge(:site_id => s))]}
+  - object ||= nil
 
-- options = [[@site.label, request.fullpath]] + options
+  - options = case object
+    - when ::Comfy::Cms::Layout
+      - object.mirrors.collect{|m| [m.site.label, edit_comfy_admin_cms_site_layout_path(m.site, m)]}
+    - when ::Comfy::Cms::Page
+      - object.mirrors.collect{|m| [m.site.label, edit_comfy_admin_cms_site_page_path(m.site, m)]}
+    - when ::Comfy::Cms::Snippet
+      - object.mirrors.collect{|m| [m.site.label, edit_comfy_admin_cms_site_snippet_path(m.site, m)]}
+    - else
+      - (::Comfy::Cms::Site.mirrored - [@site]).collect{|s| [s.label, url_for(params.permit!.merge(:site_id => s))]}
 
-#mirrors.box
-  = select_tag :mirror, options_for_select(options)
+  - options = [[@site.label, request.fullpath]] + options
+
+  #mirrors.box
+    = select_tag :mirror, options_for_select(options)


### PR DESCRIPTION
### Summary

This fixes the error when returning nil from 'comfy/admin/cms/sites/mirrors'.

![Screen Shot 2019-06-07 at 8 14 50 AM](https://user-images.githubusercontent.com/3773866/59074079-7524e880-88fc-11e9-9429-dbeb8fc6c4b9.png)



