### PR TITLE
allow configuration of comfy model base class

### DIFF
--- a/app/models/comfy/cms/categorization.rb
+++ b/app/models/comfy/cms/categorization.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Comfy::Cms::Categorization < ActiveRecord::Base
+class Comfy::Cms::Categorization < ComfortableMexicanSofa.config.base_model.to_s.constantize
 
   self.table_name = "comfy_cms_categorizations"
 

--- a/app/models/comfy/cms/category.rb
+++ b/app/models/comfy/cms/category.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Comfy::Cms::Category < ActiveRecord::Base
+class Comfy::Cms::Category < ComfortableMexicanSofa.config.base_model.to_s.constantize
 
   self.table_name = "comfy_cms_categories"
 

--- a/app/models/comfy/cms/file.rb
+++ b/app/models/comfy/cms/file.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Comfy::Cms::File < ActiveRecord::Base
+class Comfy::Cms::File < ComfortableMexicanSofa.config.base_model.to_s.constantize
 
   self.table_name = "comfy_cms_files"
 

--- a/app/models/comfy/cms/fragment.rb
+++ b/app/models/comfy/cms/fragment.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Comfy::Cms::Fragment < ActiveRecord::Base
+class Comfy::Cms::Fragment < ComfortableMexicanSofa.config.base_model.to_s.constantize
 
   self.table_name = "comfy_cms_fragments"
 

--- a/app/models/comfy/cms/layout.rb
+++ b/app/models/comfy/cms/layout.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Comfy::Cms::Layout < ActiveRecord::Base
+class Comfy::Cms::Layout < ComfortableMexicanSofa.config.base_model.to_s.constantize
 
   self.table_name = "comfy_cms_layouts"
 

--- a/app/models/comfy/cms/page.rb
+++ b/app/models/comfy/cms/page.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Comfy::Cms::Page < ActiveRecord::Base
+class Comfy::Cms::Page < ComfortableMexicanSofa.config.base_model.to_s.constantize
 
   self.table_name = "comfy_cms_pages"
 

--- a/app/models/comfy/cms/revision.rb
+++ b/app/models/comfy/cms/revision.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Comfy::Cms::Revision < ActiveRecord::Base
+class Comfy::Cms::Revision < ComfortableMexicanSofa.config.base_model.to_s.constantize
 
   self.table_name = "comfy_cms_revisions"
 

--- a/app/models/comfy/cms/site.rb
+++ b/app/models/comfy/cms/site.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Comfy::Cms::Site < ActiveRecord::Base
+class Comfy::Cms::Site < ComfortableMexicanSofa.config.base_model.to_s.constantize
 
   self.table_name = "comfy_cms_sites"
 

--- a/app/models/comfy/cms/snippet.rb
+++ b/app/models/comfy/cms/snippet.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Comfy::Cms::Snippet < ActiveRecord::Base
+class Comfy::Cms::Snippet < ComfortableMexicanSofa.config.base_model.to_s.constantize
 
   self.table_name = "comfy_cms_snippets"
 

--- a/app/models/comfy/cms/translation.rb
+++ b/app/models/comfy/cms/translation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Comfy::Cms::Translation < ActiveRecord::Base
+class Comfy::Cms::Translation < ComfortableMexicanSofa.config.base_model.to_s.constantize
 
   self.table_name = "comfy_cms_translations"
 

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -10,6 +10,9 @@ ComfortableMexicanSofa.configure do |config|
   # Controller that Comfy::Cms::BaseController will inherit from
   #   config.public_base_controller = 'ApplicationController'
 
+  # Model that Comfy models will inherit from
+  #   config.base_model = 'ActiveRecord::Base'
+
   # Module responsible for authentication. You can replace it with your own.
   # It simply needs to have #authenticate method. See http_auth.rb for reference.
   #   config.admin_auth = 'ComfyAdminAuthentication'

--- a/lib/comfortable_mexican_sofa/configuration.rb
+++ b/lib/comfortable_mexican_sofa/configuration.rb
@@ -9,6 +9,10 @@ class ComfortableMexicanSofa::Configuration
   # 'ApplicationController' is the default
   attr_accessor :admin_base_controller
 
+  # Model that Comfy models will inherit from
+  # 'ApplicationRecord' is the default
+  attr_accessor :base_model
+
   # Controller that Comfy::Cms::BaseController will inherit from
   # 'ApplicationController' is the default
   attr_accessor :public_base_controller
@@ -90,6 +94,7 @@ class ComfortableMexicanSofa::Configuration
     @cms_title              = "ComfortableMexicanSofa CMS Engine"
     @admin_base_controller  = "ApplicationController"
     @public_base_controller = "ApplicationController"
+    @base_model             = "ActiveRecord::Base"
     @admin_auth             = "ComfortableMexicanSofa::AccessControl::AdminAuthentication"
     @admin_authorization    = "ComfortableMexicanSofa::AccessControl::AdminAuthorization"
     @public_auth            = "ComfortableMexicanSofa::AccessControl::PublicAuthentication"

--- a/test/lib/configuration_test.rb
+++ b/test/lib/configuration_test.rb
@@ -9,6 +9,7 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal "ComfortableMexicanSofa CMS Engine", config.cms_title
     assert_equal "ApplicationController", config.admin_base_controller
     assert_equal "ApplicationController", config.public_base_controller
+    assert_equal "ActiveRecord::Base", config.base_model
     assert_equal "ComfortableMexicanSofa::AccessControl::AdminAuthentication",  config.admin_auth
     assert_equal "ComfortableMexicanSofa::AccessControl::AdminAuthorization",   config.admin_authorization
     assert_equal "ComfortableMexicanSofa::AccessControl::PublicAuthentication", config.public_auth


### PR DESCRIPTION
It is useful to be able to put the CMS in a separate database, and for this being able to configure the superclass of the Comfy models is necessary, regardless of which mechanism of multi-database support one chooses.
