### PR TITLE
Convert ES6 JS files to ES5

### DIFF
--- a/app/assets/javascripts/comfy/admin/cms/base.js
+++ b/app/assets/javascripts/comfy/admin/cms/base.js
@@ -1,24 +1,26 @@
-(() => {
-  if (!window.CMS) window.CMS = {};
-  const CMS = window.CMS;
+"use strict";
 
-  // TODO(glebm): Use the battle-tested universal onPageLoad code and enable Turbolinks+async in the demo app.
+(function () {
+  if (!window.CMS) window.CMS = {};
+  var CMS = window.CMS; // TODO(glebm): Use the battle-tested universal onPageLoad code and enable Turbolinks+async in the demo app.
   // See: https://gist.github.com/glebm/2496daf445877055447a6fac46509d9a
-  const isTurbolinks = 'Turbolinks' in window && window.Turbolinks.supported;
+
+  var isTurbolinks = 'Turbolinks' in window && window.Turbolinks.supported;
+
   if (isTurbolinks) {
-    document.addEventListener('turbolinks:load', () => {
+    document.addEventListener('turbolinks:load', function () {
       window.CMS.init();
     });
-    document.addEventListener('turbolinks:before-cache', () => {
+    document.addEventListener('turbolinks:before-cache', function () {
       window.CMS.dispose();
     });
   } else {
-    document.addEventListener('DOMContentLoaded', () => {
+    document.addEventListener('DOMContentLoaded', function () {
       window.CMS.init();
     });
   }
 
-  CMS.init = () => {
+  CMS.init = function () {
     CMS.current_path = window.location.pathname;
     CMS.slugify();
     CMS.codemirror.init();
@@ -33,7 +35,7 @@
     CMS.diff();
   };
 
-  CMS.dispose = () => {
+  CMS.dispose = function () {
     CMS.codemirror.dispose();
     CMS.wysiwyg.dispose();
     CMS.files.dispose();
@@ -42,5 +44,7 @@
     CMS.timepicker.dispose();
   };
 
-  CMS.getLocale = () => document.querySelector('meta[name="cms-locale"]').content;
+  CMS.getLocale = function () {
+    return document.querySelector('meta[name="cms-locale"]').content;
+  };
 })();

--- a/app/assets/javascripts/comfy/admin/cms/categories.js
+++ b/app/assets/javascripts/comfy/admin/cms/categories.js
@@ -1,17 +1,19 @@
-(() => {
-  window.CMS.categories = (root = document) => {
-    const widget = root.querySelector('.categories-widget');
+"use strict";
+
+(function () {
+  window.CMS.categories = function () {
+    var root = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : document;
+    var widget = root.querySelector('.categories-widget');
     if (widget === null) return;
-    const readSection = widget.querySelector('.read');
-    const editSection = widget.querySelector('.editable');
-    widget.querySelector('.read button.toggle-cat-edit').addEventListener('click', () => {
+    var readSection = widget.querySelector('.read');
+    var editSection = widget.querySelector('.editable');
+    widget.querySelector('.read button.toggle-cat-edit').addEventListener('click', function () {
       readSection.style.display = 'none';
       editSection.style.display = 'block';
     });
-    widget.querySelector('.editable button.toggle-cat-edit').addEventListener('click', () => {
+    widget.querySelector('.editable button.toggle-cat-edit').addEventListener('click', function () {
       editSection.style.display = 'none';
       readSection.style.display = 'block';
     });
   };
 })();
-

--- a/app/assets/javascripts/comfy/admin/cms/codemirror.js
+++ b/app/assets/javascripts/comfy/admin/cms/codemirror.js
@@ -1,31 +1,95 @@
-(() => {
-  const codeMirrorInstances = [];
+"use strict";
+
+(function () {
+  var codeMirrorInstances = [];
   window.CMS.codemirror = {
-    init(root = document) {
-      for (const textarea of root.querySelectorAll('textarea[data-cms-cm-mode]')) {
-        const codemirror = CodeMirror.fromTextArea(textarea, {
-          mode: textarea.dataset.cmsCmMode,
-          tabSize: 2,
-          lineWrapping: true,
-          autoCloseTags: true,
-          lineNumbers: true,
-          viewportMargin: Infinity
-        });
-        codeMirrorInstances.push(codemirror);
+    init: function init() {
+      var root = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : document;
+      var _iteratorNormalCompletion = true;
+      var _didIteratorError = false;
+      var _iteratorError = undefined;
+
+      try {
+        for (var _iterator = root.querySelectorAll('textarea[data-cms-cm-mode]')[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+          var textarea = _step.value;
+          var codemirror = CodeMirror.fromTextArea(textarea, {
+            mode: textarea.dataset.cmsCmMode,
+            tabSize: 2,
+            lineWrapping: true,
+            autoCloseTags: true,
+            lineNumbers: true,
+            viewportMargin: Infinity
+          });
+          codeMirrorInstances.push(codemirror);
+        }
+      } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion && _iterator.return != null) {
+            _iterator.return();
+          }
+        } finally {
+          if (_didIteratorError) {
+            throw _iteratorError;
+          }
+        }
       }
 
-      const tabsRoot = root.id === 'form-fragments' ? root : root.querySelector('#form-fragments');
-      jQuery(tabsRoot).find('a[data-toggle="tab"]').on('shown.bs.tab', () => {
-        for (const codemirror of codeMirrorInstances) {
-          codemirror.refresh();
+      var tabsRoot = root.id === 'form-fragments' ? root : root.querySelector('#form-fragments');
+      jQuery(tabsRoot).find('a[data-toggle="tab"]').on('shown.bs.tab', function () {
+        var _iteratorNormalCompletion2 = true;
+        var _didIteratorError2 = false;
+        var _iteratorError2 = undefined;
+
+        try {
+          for (var _iterator2 = codeMirrorInstances[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+            var codemirror = _step2.value;
+            codemirror.refresh();
+          }
+        } catch (err) {
+          _didIteratorError2 = true;
+          _iteratorError2 = err;
+        } finally {
+          try {
+            if (!_iteratorNormalCompletion2 && _iterator2.return != null) {
+              _iterator2.return();
+            }
+          } finally {
+            if (_didIteratorError2) {
+              throw _iteratorError2;
+            }
+          }
         }
       });
     },
-    dispose() {
-      for (const codemirror of codeMirrorInstances) {
-        codemirror.toTextArea();
+    dispose: function dispose() {
+      var _iteratorNormalCompletion3 = true;
+      var _didIteratorError3 = false;
+      var _iteratorError3 = undefined;
+
+      try {
+        for (var _iterator3 = codeMirrorInstances[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+          var codemirror = _step3.value;
+          codemirror.toTextArea();
+        }
+      } catch (err) {
+        _didIteratorError3 = true;
+        _iteratorError3 = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion3 && _iterator3.return != null) {
+            _iterator3.return();
+          }
+        } finally {
+          if (_didIteratorError3) {
+            throw _iteratorError3;
+          }
+        }
       }
+
       codeMirrorInstances.length = 0;
     }
-}
+  };
 })();

--- a/app/assets/javascripts/comfy/admin/cms/diff.js
+++ b/app/assets/javascripts/comfy/admin/cms/diff.js
@@ -1,10 +1,12 @@
-(() => {
-  window.CMS.diff = () => {
+"use strict";
+
+(function () {
+  window.CMS.diff = function () {
     jQuery('.revision').prettyTextDiff({
       cleanup: true,
       originalContainer: '.original',
       changedContainer: '.current',
-      diffContainer: '.diff .content',
+      diffContainer: '.diff .content'
     });
-  }
+  };
 })();

--- a/app/assets/javascripts/comfy/admin/cms/file_link.js
+++ b/app/assets/javascripts/comfy/admin/cms/file_link.js
@@ -1,13 +1,28 @@
-(() => {
-  const isFirefox = /\bFirefox\//.test(navigator.userAgent);
+"use strict";
 
-  class FileLink {
-    constructor(link) {
+function _instanceof(left, right) { if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) { return !!right[Symbol.hasInstance](left); } else { return left instanceof right; } }
+
+function _classCallCheck(instance, Constructor) { if (!_instanceof(instance, Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+(function () {
+  var isFirefox = /\bFirefox\//.test(navigator.userAgent);
+
+  var FileLink =
+  /*#__PURE__*/
+  function () {
+    function FileLink(link) {
+      var _this = this;
+
+      _classCallCheck(this, FileLink);
+
       this.link = link;
       this.isImage = !!link.dataset.cmsFileThumbUrl;
-
-      link.addEventListener('dragstart', (evt) => {
-        evt.dataTransfer.setData('text/plain', this.link.dataset.cmsFileLinkTag);
+      link.addEventListener('dragstart', function (evt) {
+        evt.dataTransfer.setData('text/plain', _this.link.dataset.cmsFileLinkTag);
       });
 
       if (this.isImage) {
@@ -18,50 +33,80 @@
           content: this.buildFileThumbnail(),
           html: true
         });
+        link.addEventListener('dragstart', function (evt) {
+          evt.dataTransfer.setDragImage(_this.buildFileThumbnail(), 4, 2);
 
-        link.addEventListener('dragstart', (evt) => {
-          evt.dataTransfer.setDragImage(this.buildFileThumbnail(), 4, 2);
-          this.getPopover().hide();
+          _this.getPopover().hide();
         });
-
         this.workAroundFirefoxPopoverGlitch();
       }
     }
 
-    buildFileThumbnail() {
-      const img = new Image();
-      img.src = this.link.dataset.cmsFileThumbUrl;
-      return img;
-    }
+    _createClass(FileLink, [{
+      key: "buildFileThumbnail",
+      value: function buildFileThumbnail() {
+        var img = new Image();
+        img.src = this.link.dataset.cmsFileThumbUrl;
+        return img;
+      } // To work around a Firefox bug causing the popover to re-appear after the drop:
+      // https://github.com/comfy/comfortable-mexican-sofa/pull/799#issuecomment-369124161
+      //
+      // Possibly related to:
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=505521
 
-    // To work around a Firefox bug causing the popover to re-appear after the drop:
-    // https://github.com/comfy/comfortable-mexican-sofa/pull/799#issuecomment-369124161
-    //
-    // Possibly related to:
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=505521
-    workAroundFirefoxPopoverGlitch() {
-      if (!isFirefox) return;
-      this.link.addEventListener('dragstart', () => {
-        this.getPopover().disable();
-      });
-      this.link.addEventListener('dragend', () => {
-        setTimeout(() => {
-          const popover = this.getPopover();
-          popover.enable();
-          popover.hide();
-        }, 300);
-      });
-    }
+    }, {
+      key: "workAroundFirefoxPopoverGlitch",
+      value: function workAroundFirefoxPopoverGlitch() {
+        var _this2 = this;
 
-    // We can't keep a reference to the Popover object, because Bootstrap re-creates it internally.
-    getPopover() {
-      return jQuery(this.link).data(bootstrap.Popover.DATA_KEY);
-    }
-  }
+        if (!isFirefox) return;
+        this.link.addEventListener('dragstart', function () {
+          _this2.getPopover().disable();
+        });
+        this.link.addEventListener('dragend', function () {
+          setTimeout(function () {
+            var popover = _this2.getPopover();
 
-  window.CMS.fileLinks = (root = document) => {
-    for (const link of root.querySelectorAll('[data-cms-file-link-tag]')) {
-      new FileLink(link);
+            popover.enable();
+            popover.hide();
+          }, 300);
+        });
+      } // We can't keep a reference to the Popover object, because Bootstrap re-creates it internally.
+
+    }, {
+      key: "getPopover",
+      value: function getPopover() {
+        return jQuery(this.link).data(bootstrap.Popover.DATA_KEY);
+      }
+    }]);
+
+    return FileLink;
+  }();
+
+  window.CMS.fileLinks = function () {
+    var root = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : document;
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+      for (var _iterator = root.querySelectorAll('[data-cms-file-link-tag]')[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+        var link = _step.value;
+        new FileLink(link);
+      }
+    } catch (err) {
+      _didIteratorError = true;
+      _iteratorError = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion && _iterator.return != null) {
+          _iterator.return();
+        }
+      } finally {
+        if (_didIteratorError) {
+          throw _iteratorError;
+        }
+      }
     }
   };
 })();

--- a/app/assets/javascripts/comfy/admin/cms/file_upload.js
+++ b/app/assets/javascripts/comfy/admin/cms/file_upload.js
@@ -1,193 +1,329 @@
+"use strict";
+
+function _instanceof(left, right) { if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) { return !!right[Symbol.hasInstance](left); } else { return left instanceof right; } }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+function _classCallCheck(instance, Constructor) { if (!_instanceof(instance, Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
 //= require comfy/vendor/moxie.min
 //= require comfy/vendor/plupload.dev
+(function () {
+  var DROP_TARGET_ACTIVE_CLASS = 'cms-uploader-drag-drop-target-active';
 
-(() => {
-  const DROP_TARGET_ACTIVE_CLASS = 'cms-uploader-drag-drop-target-active';
+  var FileUpload =
+  /*#__PURE__*/
+  function () {
+    function FileUpload(container, settings) {
+      var _this = this;
 
-  class FileUpload {
-    constructor(container, settings) {
+      _classCallCheck(this, FileUpload);
+
       if (!container.id) container.id = plupload.guid();
       settings = Object.assign(FileUpload.defaultUploaderSettings(container.id), settings);
       this.ui = {
-        container,
+        container: container,
         list: container.querySelector('.cms-uploader-filelist'),
-        dropElement: container.querySelector(`#${settings.drop_element}`),
+        dropElement: container.querySelector("#".concat(settings.drop_element))
       };
       this.cleanupFns = [];
       this.uploader = new plupload.Uploader(settings);
-      this.uploader.bind('PostInit', () => this.onUploaderPostInit());
-      this.uploader.bind('Error', (_uploader, error) => this.onUploaderError(error));
-      this.uploader.bind('FilesAdded', (_uploader, files) => this.onUploaderFilesAdded(files));
-      this.uploader.bind('UploadProgress', (_uploader, file) => this.onUploaderUploadProgress(file));
-      this.uploader.bind('FileUploaded', (_uploader, file, info) => this.onUploaderFileUploaded(file, info));
-      this.uploader.bind('FilesRemoved', (_uploader, files) => this.onUploaderFilesRemoved(files));
+      this.uploader.bind('PostInit', function () {
+        return _this.onUploaderPostInit();
+      });
+      this.uploader.bind('Error', function (_uploader, error) {
+        return _this.onUploaderError(error);
+      });
+      this.uploader.bind('FilesAdded', function (_uploader, files) {
+        return _this.onUploaderFilesAdded(files);
+      });
+      this.uploader.bind('UploadProgress', function (_uploader, file) {
+        return _this.onUploaderUploadProgress(file);
+      });
+      this.uploader.bind('FileUploaded', function (_uploader, file, info) {
+        return _this.onUploaderFileUploaded(file, info);
+      });
+      this.uploader.bind('FilesRemoved', function (_uploader, files) {
+        return _this.onUploaderFilesRemoved(files);
+      });
       this.uploader.init();
+
       if (settings.setup) {
         settings.setup(this.uploader);
       }
     }
 
-    destroy() {
-      this.uploader.destroy();
-      for (const cleanupFn of this.cleanupFns) {
-        cleanupFn();
-      }
-    }
+    _createClass(FileUpload, [{
+      key: "destroy",
+      value: function destroy() {
+        this.uploader.destroy();
+        var _iteratorNormalCompletion = true;
+        var _didIteratorError = false;
+        var _iteratorError = undefined;
 
-    addCleanup(cleanupFn) {
-      this.cleanupFns.push(cleanupFn);
-    }
-
-    onUploaderPostInit() {
-      // Show drag and drop info and attach events only if drag and drop is enabled and supported.
-      if (!this.uploader.settings.dragdrop || !this.uploader.features.dragdrop) {
-        this.ui.container.querySelector('.cms-uploader-drag-drop-info').style.display = 'none';
-        return;
-      }
-      // When dragging over the document add a class to the drop target that puts it on top of every element and remove
-      // that class when dropping or leaving the drop target. Otherwise the dragleave event would fire whenever we drag
-      // over a child element inside the drop target such as text nodes.
-      const onDragEnter = (e) => {
-        // Only react to drag'n'drops that contain a file. See:
-        // https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/types
-        if (e.dataTransfer.types.includes('Files')) {
-          this.ui.dropElement.classList.add(DROP_TARGET_ACTIVE_CLASS);
+        try {
+          for (var _iterator = this.cleanupFns[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+            var cleanupFn = _step.value;
+            cleanupFn();
+          }
+        } catch (err) {
+          _didIteratorError = true;
+          _iteratorError = err;
+        } finally {
+          try {
+            if (!_iteratorNormalCompletion && _iterator.return != null) {
+              _iterator.return();
+            }
+          } finally {
+            if (_didIteratorError) {
+              throw _iteratorError;
+            }
+          }
         }
-      };
-      document.addEventListener('dragenter', onDragEnter);
-      this.addCleanup(() => {
-        document.removeEventListener('dragenter', onDragEnter);
-      });
-      for (const eventName of ['drop', 'dragleave']) {
-        this.ui.dropElement.addEventListener(eventName, () => {
-          this.ui.dropElement.classList.remove(DROP_TARGET_ACTIVE_CLASS);
+      }
+    }, {
+      key: "addCleanup",
+      value: function addCleanup(cleanupFn) {
+        this.cleanupFns.push(cleanupFn);
+      }
+    }, {
+      key: "onUploaderPostInit",
+      value: function onUploaderPostInit() {
+        var _this2 = this;
+
+        // Show drag and drop info and attach events only if drag and drop is enabled and supported.
+        if (!this.uploader.settings.dragdrop || !this.uploader.features.dragdrop) {
+          this.ui.container.querySelector('.cms-uploader-drag-drop-info').style.display = 'none';
+          return;
+        } // When dragging over the document add a class to the drop target that puts it on top of every element and remove
+        // that class when dropping or leaving the drop target. Otherwise the dragleave event would fire whenever we drag
+        // over a child element inside the drop target such as text nodes.
+
+
+        var onDragEnter = function onDragEnter(e) {
+          // Only react to drag'n'drops that contain a file. See:
+          // https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/types
+          if (e.dataTransfer.types.includes('Files')) {
+            _this2.ui.dropElement.classList.add(DROP_TARGET_ACTIVE_CLASS);
+          }
+        };
+
+        document.addEventListener('dragenter', onDragEnter);
+        this.addCleanup(function () {
+          document.removeEventListener('dragenter', onDragEnter);
         });
+
+        for (var _i = 0, _arr = ['drop', 'dragleave']; _i < _arr.length; _i++) {
+          var eventName = _arr[_i];
+          this.ui.dropElement.addEventListener(eventName, function () {
+            _this2.ui.dropElement.classList.remove(DROP_TARGET_ACTIVE_CLASS);
+          });
+        }
       }
-    }
+    }, {
+      key: "onUploaderError",
+      value: function onUploaderError(error) {
+        if (error.code === plupload.INIT_ERROR) {
+          window.alert('Error: Initialisation error. Reload to try again.');
+          return;
+        }
 
-    onUploaderError(error) {
-      if (error.code === plupload.INIT_ERROR) {
-        window.alert('Error: Initialisation error. Reload to try again.');
-        return;
+        var file = error.file;
+        if (!file) return; // Get error message from the server response. Not all runtimes support this.
+
+        var message = error.response; // If no error message is in the server response get standard plupload error messages.
+        // This will have descriptive error message for something like file size or file format errors but for
+        // server errors it will only display a general error message.
+
+        if (!message) {
+          message = error.message;
+          if (error.details) message += " (".concat(error.details, ")");
+        }
+
+        file.status = plupload.FAILED;
+        file.error_message = message;
+        this.updateFileStatus(file);
       }
-      const file = error.file;
-      if (!file) return;
-      // Get error message from the server response. Not all runtimes support this.
-      let message = error.response;
-      // If no error message is in the server response get standard plupload error messages.
-      // This will have descriptive error message for something like file size or file format errors but for
-      // server errors it will only display a general error message.
-      if (!message) {
-        message = error.message;
-        if (error.details) message += ` (${error.details})`;
+    }, {
+      key: "onUploaderFilesAdded",
+      value: function onUploaderFilesAdded(files) {
+        var _iteratorNormalCompletion2 = true;
+        var _didIteratorError2 = false;
+        var _iteratorError2 = undefined;
+
+        try {
+          for (var _iterator2 = files[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+            var file = _step2.value;
+            this.addFile(file);
+          } // Auto start upload when files are added.
+
+        } catch (err) {
+          _didIteratorError2 = true;
+          _iteratorError2 = err;
+        } finally {
+          try {
+            if (!_iteratorNormalCompletion2 && _iterator2.return != null) {
+              _iterator2.return();
+            }
+          } finally {
+            if (_didIteratorError2) {
+              throw _iteratorError2;
+            }
+          }
+        }
+
+        this.uploader.start();
       }
-      file.status = plupload.FAILED;
-      file.error_message = message;
-      this.updateFileStatus(file);
-    }
-
-    onUploaderFilesAdded(files) {
-      for (const file of files) {
-        this.addFile(file);
+    }, {
+      key: "onUploaderUploadProgress",
+      value: function onUploaderUploadProgress(file) {
+        this.updateFileStatus(file);
       }
-      // Auto start upload when files are added.
-      this.uploader.start();
-    }
-
-    onUploaderUploadProgress(file) {
-      this.updateFileStatus(file);
-    }
-
-    onUploaderFileUploaded(file, info) {
-      // Replace the dummy file entry in the file list with the the entry from the server response.
-      const template = document.createElement('template');
-      template.innerHTML = info.response;
-      const newListItem = template.content.firstElementChild;
-      this.ui.list.replaceChild(newListItem, this.fileListItem(file));
-      window.CMS.fileLinks(newListItem);
-    }
-
-    onUploaderFilesRemoved(files) {
-      for (const file of files) {
-        this.removeFile(file);
+    }, {
+      key: "onUploaderFileUploaded",
+      value: function onUploaderFileUploaded(file, info) {
+        // Replace the dummy file entry in the file list with the the entry from the server response.
+        var template = document.createElement('template');
+        template.innerHTML = info.response;
+        var newListItem = template.content.firstElementChild;
+        this.ui.list.replaceChild(newListItem, this.fileListItem(file));
+        window.CMS.fileLinks(newListItem);
       }
-    }
+    }, {
+      key: "onUploaderFilesRemoved",
+      value: function onUploaderFilesRemoved(files) {
+        var _iteratorNormalCompletion3 = true;
+        var _didIteratorError3 = false;
+        var _iteratorError3 = undefined;
 
-    addFile(file) {
-      this.ui.list.insertAdjacentHTML('afterbegin', FileUpload.buildListItemHTML(file));
-      this.fileListItem(file).querySelector('.cms-uploader-file-delete').addEventListener('click', (evt) => {
-        evt.preventDefault();
-        this.uploader.removeFile(file);
-      });
-      this.updateFileStatus(file);
-    }
-
-    removeFile(file) {
-      this.fileListItem(file).remove();
-    }
-
-    updateFileStatus(file) {
-      const progressBar = this.fileListItem(file).querySelector('.progress-bar');
-      switch (file.status) {
-        case plupload.UPLOADING:
-          progressBar.style.width = `${file.percent}%`;
-          break;
-        case plupload.FAILED:
-          progressBar.style.width = '100%';
-          progressBar.classList.add('progress-bar-danger');
-          progressBar.querySelector('span').innerHTML = file.error_message;
-          break;
+        try {
+          for (var _iterator3 = files[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+            var file = _step3.value;
+            this.removeFile(file);
+          }
+        } catch (err) {
+          _didIteratorError3 = true;
+          _iteratorError3 = err;
+        } finally {
+          try {
+            if (!_iteratorNormalCompletion3 && _iterator3.return != null) {
+              _iterator3.return();
+            }
+          } finally {
+            if (_didIteratorError3) {
+              throw _iteratorError3;
+            }
+          }
+        }
       }
-    }
+    }, {
+      key: "addFile",
+      value: function addFile(file) {
+        var _this3 = this;
 
-    fileListItem({id}) {
-      return this.ui.container.querySelector(`#${id}`);
-    }
+        this.ui.list.insertAdjacentHTML('afterbegin', FileUpload.buildListItemHTML(file));
+        this.fileListItem(file).querySelector('.cms-uploader-file-delete').addEventListener('click', function (evt) {
+          evt.preventDefault();
 
-    static buildListItemHTML({id, name}) {
-      return `<li id='${id}' class='row temp'>
-        <div class='col-md-9 d-flex align-items-center'>
-          <div class='progress'>
-            <div class='progress-bar progress-bar-striped progress-bar-animated'>
-              <span>${name}</span>
-            </div>
-          </div>
-        </div>
-        <div class='col-md-3 d-flex align-items-center justify-content-md-end'>
-          <a class='btn btn-sm btn-danger float-right cms-uploader-file-delete' href='#'>Delete</a>
-        </div>
-      </li>`;
-    }
+          _this3.uploader.removeFile(file);
+        });
+        this.updateFileStatus(file);
+      }
+    }, {
+      key: "removeFile",
+      value: function removeFile(file) {
+        this.fileListItem(file).remove();
+      }
+    }, {
+      key: "updateFileStatus",
+      value: function updateFileStatus(file) {
+        var progressBar = this.fileListItem(file).querySelector('.progress-bar');
 
-    static defaultUploaderSettings(id) {
-      return {
-        runtimes: 'html5,browserplus,silverlight,flash,gears',
-        dragdrop: true,
-        drop_element: `${id}-drag-drop-target`,
-        browse_button: `${id}-browse`,
-        container: id,
-        file_data_name: 'file[file]',
-      };
-    }
-  }
+        switch (file.status) {
+          case plupload.UPLOADING:
+            progressBar.style.width = "".concat(file.percent, "%");
+            break;
 
-  const uploaders = [];
+          case plupload.FAILED:
+            progressBar.style.width = '100%';
+            progressBar.classList.add('progress-bar-danger');
+            progressBar.querySelector('span').innerHTML = file.error_message;
+            break;
+        }
+      }
+    }, {
+      key: "fileListItem",
+      value: function fileListItem(_ref) {
+        var id = _ref.id;
+        return this.ui.container.querySelector("#".concat(id));
+      }
+    }], [{
+      key: "buildListItemHTML",
+      value: function buildListItemHTML(_ref2) {
+        var id = _ref2.id,
+            name = _ref2.name;
+        return "<li id='".concat(id, "' class='row temp'>\n        <div class='col-md-9 d-flex align-items-center'>\n          <div class='progress'>\n            <div class='progress-bar progress-bar-striped progress-bar-animated'>\n              <span>").concat(name, "</span>\n            </div>\n          </div>\n        </div>\n        <div class='col-md-3 d-flex align-items-center justify-content-md-end'>\n          <a class='btn btn-sm btn-danger float-right cms-uploader-file-delete' href='#'>Delete</a>\n        </div>\n      </li>");
+      }
+    }, {
+      key: "defaultUploaderSettings",
+      value: function defaultUploaderSettings(id) {
+        return {
+          runtimes: 'html5,browserplus,silverlight,flash,gears',
+          dragdrop: true,
+          drop_element: "".concat(id, "-drag-drop-target"),
+          browse_button: "".concat(id, "-browse"),
+          container: id,
+          file_data_name: 'file[file]'
+        };
+      }
+    }]);
+
+    return FileUpload;
+  }();
+
+  var uploaders = [];
   window.CMS.fileUpload = {
-    init(root = document) {
-      const el = root.querySelector('#cms-uploader');
+    init: function init() {
+      var _multipart_params;
+
+      var root = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : document;
+      var el = root.querySelector('#cms-uploader');
       if (el === null) return;
       uploaders.push(new FileUpload(el, {
         url: el.dataset.cmsUploaderUrl,
-        multipart_params: {
-          [el.dataset.cmsUploaderTokenName]: el.dataset.cmsUploaderTokenValue,
-          [el.dataset.cmsUploaderSessionName]: el.dataset.cmsUploaderSessionValue
-        }
+        multipart_params: (_multipart_params = {}, _defineProperty(_multipart_params, el.dataset.cmsUploaderTokenName, el.dataset.cmsUploaderTokenValue), _defineProperty(_multipart_params, el.dataset.cmsUploaderSessionName, el.dataset.cmsUploaderSessionValue), _multipart_params)
       }));
     },
-    dispose() {
-      for (const uploader of uploader) {
-        uploader.dispose();
+    dispose: function dispose() {
+      var _iteratorNormalCompletion4 = true;
+      var _didIteratorError4 = false;
+      var _iteratorError4 = undefined;
+
+      try {
+        for (var _iterator4 = uploader[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+          var _uploader2 = _step4.value;
+
+          _uploader2.dispose();
+        }
+      } catch (err) {
+        _didIteratorError4 = true;
+        _iteratorError4 = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion4 && _iterator4.return != null) {
+            _iterator4.return();
+          }
+        } finally {
+          if (_didIteratorError4) {
+            throw _iteratorError4;
+          }
+        }
       }
+
       uploaders.length = 0;
     }
   };

--- a/app/assets/javascripts/comfy/admin/cms/files_modal.js
+++ b/app/assets/javascripts/comfy/admin/cms/files_modal.js
@@ -1,35 +1,40 @@
-// Site files modal.
-(() => {
-  let modal = null;
+"use strict";
 
-  const initModalContent = (modalContent) => {
+// Site files modal.
+(function () {
+  var modal = null;
+
+  var initModalContent = function initModalContent(modalContent) {
     window.CMS.fileUpload.init(modalContent);
     window.CMS.fileLinks(modalContent);
-    modalContent.addEventListener('dragstart', (evt) => {
-      if (evt.target.nodeType === Node.ELEMENT_NODE &&
-          evt.target.matches('.cms-uploader-filelist .item-title a') && modal != null) {
+    modalContent.addEventListener('dragstart', function (evt) {
+      if (evt.target.nodeType === Node.ELEMENT_NODE && evt.target.matches('.cms-uploader-filelist .item-title a') && modal != null) {
         modal.hide();
       }
     });
   };
 
   window.CMS.files = {
-    init() {
-      const modalToggle = document.querySelector('.cms-files-open-modal');
-      const modalContainer = document.querySelector('.cms-files-modal');
+    init: function init() {
+      var modalToggle = document.querySelector('.cms-files-open-modal');
+      var modalContainer = document.querySelector('.cms-files-modal');
       if (modalToggle === null || modalContainer === null) return;
-      const modalContent = modalContainer.querySelector('.modal-content');
-      modalToggle.addEventListener('click', (evt) => {
+      var modalContent = modalContainer.querySelector('.modal-content');
+      modalToggle.addEventListener('click', function (evt) {
         evt.preventDefault();
-        fetch(modalContainer.dataset.url, {credentials: 'same-origin'}).then((resp) => resp.text()).then((html) => {
-          modalContent.innerHTML = `<div class="modal-body">${html}</div>`;
+        fetch(modalContainer.dataset.url, {
+          credentials: 'same-origin'
+        }).then(function (resp) {
+          return resp.text();
+        }).then(function (html) {
+          modalContent.innerHTML = "<div class=\"modal-body\">".concat(html, "</div>");
           initModalContent(modalContent);
         });
         modal = modal || new bootstrap.Modal(modalContainer);
         modal.show();
       });
     },
-    dispose() {
+    dispose: function dispose() {
       if (modal !== null) {
         modal.hide();
         modal.dispose();

--- a/app/assets/javascripts/comfy/admin/cms/page_fragments.js
+++ b/app/assets/javascripts/comfy/admin/cms/page_fragments.js
@@ -1,19 +1,24 @@
-window.CMS.pageFragments = () => {
-  const toggle = document.querySelector('select#fragments-toggle');
+"use strict";
+
+window.CMS.pageFragments = function () {
+  var toggle = document.querySelector('select#fragments-toggle');
   if (toggle === null) return;
-  const url = new URL(toggle.dataset.url, document.location.href);
-  toggle.addEventListener('change', () => {
+  var url = new URL(toggle.dataset.url, document.location.href);
+  toggle.addEventListener('change', function () {
     url.searchParams.set('layout_id', toggle.value);
-    fetch(url, {credentials: 'same-origin'}).then((resp) => resp.text()).then((html) => {
-      const container = document.querySelector('#form-fragments-container');
-      container.innerHTML = html;
-      // TODO: Only dispose of the widgets that were within the fragment.
+    fetch(url, {
+      credentials: 'same-origin'
+    }).then(function (resp) {
+      return resp.text();
+    }).then(function (html) {
+      var container = document.querySelector('#form-fragments-container');
+      container.innerHTML = html; // TODO: Only dispose of the widgets that were within the fragment.
+
       CMS.wysiwyg.dispose();
       CMS.timepicker.dispose();
       CMS.codemirror.dispose();
+      CMS.fileLinks(container); // TODO: Container should also be passed here once the TODO above is addressed.
 
-      CMS.fileLinks(container);
-      // TODO: Container should also be passed here once the TODO above is addressed.
       CMS.wysiwyg.init();
       CMS.timepicker.init();
       CMS.codemirror.init();

--- a/app/assets/javascripts/comfy/admin/cms/slugify.js
+++ b/app/assets/javascripts/comfy/admin/cms/slugify.js
@@ -1,33 +1,54 @@
-(() => {
-  const SLUGIFY_REPLACEMENTS = [
-    [/[àáâã]/g, 'a'],
-    [/ä/g, 'ae'],
-    [/[èéëê]/g, 'e'],
-    [/[ìíïî]/g, 'i'],
-    [/[òóôõ]/g, 'o'],
-    [/ö/g, 'oe'],
-    [/[ùúû]/g, 'u'],
-    [/ü/g, 'ue'],
-    [/ñ/g, 'n'],
-    [/ç/g, 'c'],
-    [/ß/g, 'ss'],
-    [/[·\/,:;_ ]/g, '-']
-  ];
+"use strict";
 
-  const slugifyValue = (value) => {
-    let slug = value.trim().toLowerCase();
-    for (const [from, to] of SLUGIFY_REPLACEMENTS) {
-      slug = slug.replace(from, to);
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
+
+function _iterableToArrayLimit(arr, i) { if (!(Symbol.iterator in Object(arr) || Object.prototype.toString.call(arr) === "[object Arguments]")) { return; } var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+(function () {
+  var SLUGIFY_REPLACEMENTS = [[/[àáâã]/g, 'a'], [/ä/g, 'ae'], [/[èéëê]/g, 'e'], [/[ìíïî]/g, 'i'], [/[òóôõ]/g, 'o'], [/ö/g, 'oe'], [/[ùúû]/g, 'u'], [/ü/g, 'ue'], [/ñ/g, 'n'], [/ç/g, 'c'], [/ß/g, 'ss'], [/[·\/,:;_ ]/g, '-']];
+
+  var slugifyValue = function slugifyValue(value) {
+    var slug = value.trim().toLowerCase();
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+      for (var _iterator = SLUGIFY_REPLACEMENTS[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+        var _step$value = _slicedToArray(_step.value, 2),
+            from = _step$value[0],
+            to = _step$value[1];
+
+        slug = slug.replace(from, to);
+      } // Remove any other URL incompatible characters and replace multiple dashes with just a single one.
+
+    } catch (err) {
+      _didIteratorError = true;
+      _iteratorError = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion && _iterator.return != null) {
+          _iterator.return();
+        }
+      } finally {
+        if (_didIteratorError) {
+          throw _iteratorError;
+        }
+      }
     }
-    // Remove any other URL incompatible characters and replace multiple dashes with just a single one.
+
     return slug.replace(/[^a-z0-9-]/g, '').replace(/-+/g, '-');
   };
 
-  window.CMS.slugify = () => {
-    const input = document.querySelector('input[data-slugify=true]');
-    const slugInput = document.querySelector('input[data-slug]');
+  window.CMS.slugify = function () {
+    var input = document.querySelector('input[data-slugify=true]');
+    var slugInput = document.querySelector('input[data-slug]');
     if (input === null || slugInput === null) return;
-    input.addEventListener('input', () => {
+    input.addEventListener('input', function () {
       slugInput.value = slugifyValue(input.value);
     });
   };

--- a/app/assets/javascripts/comfy/admin/cms/sortable_list.js
+++ b/app/assets/javascripts/comfy/admin/cms/sortable_list.js
@@ -1,40 +1,93 @@
-(() => {
-  const Rails = window.Rails;
-  const DATA_ID_ATTRIBUTE = 'data-id';
+"use strict";
 
-  const sortableStore = {
-    get(sortable) {
-      return Array.from(sortable.el.children, (el) => el.getAttribute(DATA_ID_ATTRIBUTE));
+(function () {
+  var Rails = window.Rails;
+  var DATA_ID_ATTRIBUTE = 'data-id';
+  var sortableStore = {
+    get: function get(sortable) {
+      return Array.from(sortable.el.children, function (el) {
+        return el.getAttribute(DATA_ID_ATTRIBUTE);
+      });
     },
-    set(sortable) {
-      fetch(`${CMS.current_path}/reorder`, {
-        body: JSON.stringify({order: sortable.toArray()}),
-        headers: {'Content-Type': 'application/json', 'X-CSRF-Token': Rails.csrfToken()},
+    set: function set(sortable) {
+      fetch("".concat(CMS.current_path, "/reorder"), {
+        body: JSON.stringify({
+          order: sortable.toArray()
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': Rails.csrfToken()
+        },
         credentials: 'same-origin',
-        method: 'PUT',
+        method: 'PUT'
       });
     }
   };
-
-  const sortableInstances = [];
+  var sortableInstances = [];
   window.CMS.sortableList = {
-    init(root = document) {
-      for (const sortableRoot of root.querySelectorAll('.sortable')) {
-        sortableInstances.push(Sortable.create(sortableRoot, {
-          handle: '.dragger',
-          draggable: 'li',
-          dataIdAttr: DATA_ID_ATTRIBUTE,
-          store: sortableStore,
-          onStart: (evt) => evt.from.classList.add('sortable-active'),
-          onEnd: (evt) => evt.from.classList.remove('sortable-active')
-        }));
+    init: function init() {
+      var root = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : document;
+      var _iteratorNormalCompletion = true;
+      var _didIteratorError = false;
+      var _iteratorError = undefined;
+
+      try {
+        for (var _iterator = root.querySelectorAll('.sortable')[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+          var sortableRoot = _step.value;
+          sortableInstances.push(Sortable.create(sortableRoot, {
+            handle: '.dragger',
+            draggable: 'li',
+            dataIdAttr: DATA_ID_ATTRIBUTE,
+            store: sortableStore,
+            onStart: function onStart(evt) {
+              return evt.from.classList.add('sortable-active');
+            },
+            onEnd: function onEnd(evt) {
+              return evt.from.classList.remove('sortable-active');
+            }
+          }));
+        }
+      } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion && _iterator.return != null) {
+            _iterator.return();
+          }
+        } finally {
+          if (_didIteratorError) {
+            throw _iteratorError;
+          }
+        }
       }
     },
-    dispose() {
-      for (const sortable of sortableInstances) {
-        sortable.destroy();
+    dispose: function dispose() {
+      var _iteratorNormalCompletion2 = true;
+      var _didIteratorError2 = false;
+      var _iteratorError2 = undefined;
+
+      try {
+        for (var _iterator2 = sortableInstances[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+          var sortable = _step2.value;
+          sortable.destroy();
+        }
+      } catch (err) {
+        _didIteratorError2 = true;
+        _iteratorError2 = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion2 && _iterator2.return != null) {
+            _iterator2.return();
+          }
+        } finally {
+          if (_didIteratorError2) {
+            throw _iteratorError2;
+          }
+        }
       }
+
       sortableInstances.length = 0;
     }
-  }
+  };
 })();

--- a/app/assets/javascripts/comfy/admin/cms/timepicker.js
+++ b/app/assets/javascripts/comfy/admin/cms/timepicker.js
@@ -1,29 +1,94 @@
-(() => {
-  const flatpickrInstances = [];
+"use strict";
+
+(function () {
+  var flatpickrInstances = [];
   window.CMS.timepicker = {
-    init(root = document) {
-      const datetimes = root.querySelectorAll('input[type=text][data-cms-datetime]');
-      const dates = root.querySelectorAll('input[type=text][data-cms-date]');
+    init: function init() {
+      var root = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : document;
+      var datetimes = root.querySelectorAll('input[type=text][data-cms-datetime]');
+      var dates = root.querySelectorAll('input[type=text][data-cms-date]');
       if (datetimes.length === 0 && dates.length === 0) return;
-      const locale = CMS.getLocale();
-      for (const datetime of datetimes) {
-        flatpickrInstances.push(flatpickr(datetime, {
-          format: 'yyyy-mm-dd hh:ii',
-          enableTime: true,
-          locale: locale,
-        }));
+      var locale = CMS.getLocale();
+      var _iteratorNormalCompletion = true;
+      var _didIteratorError = false;
+      var _iteratorError = undefined;
+
+      try {
+        for (var _iterator = datetimes[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+          var datetime = _step.value;
+          flatpickrInstances.push(flatpickr(datetime, {
+            format: 'yyyy-mm-dd hh:ii',
+            enableTime: true,
+            locale: locale
+          }));
+        }
+      } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion && _iterator.return != null) {
+            _iterator.return();
+          }
+        } finally {
+          if (_didIteratorError) {
+            throw _iteratorError;
+          }
+        }
       }
-      for (const date of dates) {
-        flatpickrInstances.push(flatpickr(date, {
-          format: 'yyyy-mm-dd',
-          locale: locale,
-        }));
+
+      var _iteratorNormalCompletion2 = true;
+      var _didIteratorError2 = false;
+      var _iteratorError2 = undefined;
+
+      try {
+        for (var _iterator2 = dates[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+          var date = _step2.value;
+          flatpickrInstances.push(flatpickr(date, {
+            format: 'yyyy-mm-dd',
+            locale: locale
+          }));
+        }
+      } catch (err) {
+        _didIteratorError2 = true;
+        _iteratorError2 = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion2 && _iterator2.return != null) {
+            _iterator2.return();
+          }
+        } finally {
+          if (_didIteratorError2) {
+            throw _iteratorError2;
+          }
+        }
       }
     },
-    dispose() {
-      for (const flatpickrInstance of flatpickrInstances) {
-        flatpickrInstance.destroy();
+    dispose: function dispose() {
+      var _iteratorNormalCompletion3 = true;
+      var _didIteratorError3 = false;
+      var _iteratorError3 = undefined;
+
+      try {
+        for (var _iterator3 = flatpickrInstances[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+          var flatpickrInstance = _step3.value;
+          flatpickrInstance.destroy();
+        }
+      } catch (err) {
+        _didIteratorError3 = true;
+        _iteratorError3 = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion3 && _iterator3.return != null) {
+            _iterator3.return();
+          }
+        } finally {
+          if (_didIteratorError3) {
+            throw _iteratorError3;
+          }
+        }
       }
+
       flatpickrInstances.length = 0;
     }
   };

--- a/app/assets/javascripts/comfy/admin/cms/wysiwyg.js
+++ b/app/assets/javascripts/comfy/admin/cms/wysiwyg.js
@@ -1,32 +1,29 @@
-(() => {
-  const Rails = window.Rails;
-  const buildRedactorOptions = () => {
-    const fileUploadPath = document.querySelector('meta[name="cms-file-upload-path"]').content;
-    const pagesPath = document.querySelector('meta[name="cms-pages-path"]').content;
-    const csrfParam = Rails.csrfParam();
-    const csrfToken = Rails.csrfToken();
+"use strict";
 
-    const imageUpload = new URL(fileUploadPath, document.location.href);
+(function () {
+  var Rails = window.Rails;
+
+  var buildRedactorOptions = function buildRedactorOptions() {
+    var fileUploadPath = document.querySelector('meta[name="cms-file-upload-path"]').content;
+    var pagesPath = document.querySelector('meta[name="cms-pages-path"]').content;
+    var csrfParam = Rails.csrfParam();
+    var csrfToken = Rails.csrfToken();
+    var imageUpload = new URL(fileUploadPath, document.location.href);
     imageUpload.searchParams.set('source', 'redactor');
     imageUpload.searchParams.set('type', 'image');
     imageUpload.searchParams.set(csrfParam, csrfToken);
-
-    const imageManagerJson = new URL(fileUploadPath, document.location.href);
+    var imageManagerJson = new URL(fileUploadPath, document.location.href);
     imageManagerJson.searchParams.set('source', 'redactor');
     imageManagerJson.searchParams.set('type', 'image');
-
-    const fileUpload = new URL(fileUploadPath, document.location.href);
+    var fileUpload = new URL(fileUploadPath, document.location.href);
     fileUpload.searchParams.set('source', 'redactor');
     fileUpload.searchParams.set('type', 'file');
     fileUpload.searchParams.set(csrfParam, csrfToken);
-
-    const fileManagerJson = new URL(fileUploadPath, document.location.href);
+    var fileManagerJson = new URL(fileUploadPath, document.location.href);
     fileManagerJson.searchParams.set('source', 'redactor');
     fileManagerJson.searchParams.set('type', 'file');
-
-    const definedLinks = new URL(pagesPath, document.location.href);
+    var definedLinks = new URL(pagesPath, document.location.href);
     definedLinks.searchParams.set('source', 'redactor');
-
     return {
       minHeight: 160,
       autoresize: true,
@@ -35,31 +32,71 @@
       plugins: ['imagemanager', 'filemanager', 'table', 'video', 'definedlinks'],
       lang: CMS.getLocale(),
       convertDivs: false,
-      imageUpload,
-      imageManagerJson,
-      fileUpload,
-      fileManagerJson,
-      definedLinks
+      imageUpload: imageUpload,
+      imageManagerJson: imageManagerJson,
+      fileUpload: fileUpload,
+      fileManagerJson: fileManagerJson,
+      definedLinks: definedLinks
     };
   };
 
-  const redactorInstances = [];
+  var redactorInstances = [];
   window.CMS.wysiwyg = {
-    init(root = document) {
-      const textareas = root.querySelectorAll('textarea.rich-text-editor, textarea[data-cms-rich-text]');
+    init: function init() {
+      var root = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : document;
+      var textareas = root.querySelectorAll('textarea.rich-text-editor, textarea[data-cms-rich-text]');
       if (textareas.length === 0) return;
-      const redactorOptions = buildRedactorOptions();
-      for (const textarea of textareas) {
-        redactorInstances.push(new jQuery.Redactor(textarea, redactorOptions));
+      var redactorOptions = buildRedactorOptions();
+      var _iteratorNormalCompletion = true;
+      var _didIteratorError = false;
+      var _iteratorError = undefined;
+
+      try {
+        for (var _iterator = textareas[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+          var textarea = _step.value;
+          redactorInstances.push(new jQuery.Redactor(textarea, redactorOptions));
+        }
+      } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion && _iterator.return != null) {
+            _iterator.return();
+          }
+        } finally {
+          if (_didIteratorError) {
+            throw _iteratorError;
+          }
+        }
       }
     },
-    dispose() {
-      for (const redactor of redactorInstances) {
-        redactor.core.destroy();
+    dispose: function dispose() {
+      var _iteratorNormalCompletion2 = true;
+      var _didIteratorError2 = false;
+      var _iteratorError2 = undefined;
+
+      try {
+        for (var _iterator2 = redactorInstances[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+          var redactor = _step2.value;
+          redactor.core.destroy();
+        }
+      } catch (err) {
+        _didIteratorError2 = true;
+        _iteratorError2 = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion2 && _iterator2.return != null) {
+            _iterator2.return();
+          }
+        } finally {
+          if (_didIteratorError2) {
+            throw _iteratorError2;
+          }
+        }
       }
+
       redactorInstances.length = 0;
     }
-  }
+  };
 })();
-
-


### PR DESCRIPTION
### Summary

When @glebm converted these files from CoffeeScript to JavaScript, he used ES6. These files break on older browsers like IE 11.

I transpiled them to ES5 using babel.

I think sticking to ES5 is a better solution than adding babel gem dependency complexity.