### PR TITLE
Bugfixes for jQuery <-> Redactor conflict

### DIFF
--- a/app/assets/javascripts/comfy/admin/cms/base.js.coffee
+++ b/app/assets/javascripts/comfy/admin/cms/base.js.coffee
@@ -1,3 +1,7 @@
+if jQuery.size == undefined
+  window.jQuery.fn.size = ->
+    this.length
+
 window.CMS ||= {}
 
 window.CMS.code_mirror_instances = [ ]

--- a/comfortable_mexican_sofa.gemspec
+++ b/comfortable_mexican_sofa.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails',             '>= 5.2.0', '< 6'
   s.add_dependency 'rails-i18n',        '>= 4.0.0'
-  s.add_dependency 'bootstrap_form',    '>= 2.2.0'
+  s.add_dependency 'bootstrap_form',    '>= 2.2.0', '< 3'
   s.add_dependency 'active_link_to',    '>= 1.0.0'
   s.add_dependency 'paperclip',         '>= 4.0.0'
   s.add_dependency 'kramdown',          '>= 1.0.0'

--- a/lib/comfortable_mexican_sofa/version.rb
+++ b/lib/comfortable_mexican_sofa/version.rb
@@ -1,3 +1,3 @@
 module ComfortableMexicanSofa
-  VERSION = "1.13.0"
+  VERSION = "1.13.1"
 end


### PR DESCRIPTION
### Summary

Redactor 1 was built on top of jQuery 1.x, Rails 5.2 pulls jQuery 3. jQuery 3 has removed the jQuery.size() function which is used by Redactor 1. This PR reimplements jQuery.size() as part of the assets.

The 1.13 branch gemspec didn't limit the maximum version of bootstrap_form, as a consequence installing/updating 1.13 could pull newer version of bootstrap_form that depends on BS4, which would break the layout of custom controllers that are reusing the CMS backend