### PR TITLE
Prevent stack overflow  when attachment update is run in Rails 6

### DIFF
--- a/app/models/comfy/cms/file.rb
+++ b/app/models/comfy/cms/file.rb
@@ -56,7 +56,12 @@ protected
 
   def process_attachment
     return if @file.blank?
-    attachment.attach(@file)
+
+    # prevents stack overflow issue when attachment update is run in Rails 6
+    tmp = @file
+    @file = nil
+
+    attachment.attach(tmp)
   end
 
 end


### PR DESCRIPTION
### Summary

To replicate this bug:
Use: gem 'rails', '~> 6.0.2', '>= 6.0.2.2'

Steps:
1. Go to admin area
2. Go to Files
3. Upload a new file
4. Find the newly created file on the Files' list and click on its Edit button
5. In the file edit view, click Browse to select a new file from your system and click on the 'Update File' button

You might need to repeat step 5 twice to replicate this bug.

This PR contains a fix for this in case more people are facing this issue.