### PR TITLE
Fix "Deep tag nesting" error for render pages with hundreds of tags

### DIFF
--- a/lib/comfortable_mexican_sofa/content/renderer.rb
+++ b/lib/comfortable_mexican_sofa/content/renderer.rb
@@ -42,30 +42,28 @@ class ComfortableMexicanSofa::Content::Renderer
   # @param [Comfy::Cms::WithFragments, nil] context
   def initialize(context)
     @context = context
-    @depth   = 0
   end
 
   # This is how we render content out. Takes context (cms page) and content
   # nodes
   # @param [Array<String, ComfortableMexicanSofa::Content::Tag>]
   # @param [Boolean] allow_erb
-  def render(nodes, allow_erb = ComfortableMexicanSofa.config.allow_erb)
-    if (@depth += 1) > MAX_DEPTH
+  # @param [Integer] depth
+  def render(nodes, allow_erb = ComfortableMexicanSofa.config.allow_erb, depth = 0)
+    if (depth += 1) > MAX_DEPTH
       raise Error, "Deep tag nesting or recursive nesting detected"
     end
 
-    result = nodes.map do |node|
+    nodes.map do |node|
       case node
       when String
         sanitize_erb(node, allow_erb)
       else
         tokens  = tokenize(node.render)
         nodes   = nodes(tokens)
-        render(nodes, allow_erb || node.allow_erb?)
+        render(nodes, allow_erb || node.allow_erb?, depth)
       end
     end.flatten.join
-    @depth -= 1
-    result
   end
 
   def sanitize_erb(string, allow_erb)

--- a/lib/comfortable_mexican_sofa/content/renderer.rb
+++ b/lib/comfortable_mexican_sofa/content/renderer.rb
@@ -50,7 +50,7 @@ class ComfortableMexicanSofa::Content::Renderer
   # @param [Boolean] allow_erb
   # @param [Integer] depth
   def render(nodes, allow_erb = ComfortableMexicanSofa.config.allow_erb, depth = 0)
-    if (depth += 1) > MAX_DEPTH
+    if depth >= MAX_DEPTH
       raise Error, "Deep tag nesting or recursive nesting detected"
     end
 
@@ -61,7 +61,7 @@ class ComfortableMexicanSofa::Content::Renderer
       else
         tokens  = tokenize(node.render)
         nodes   = nodes(tokens)
-        render(nodes, allow_erb || node.allow_erb?, depth)
+        render(nodes, allow_erb || node.allow_erb?, depth.next)
       end
     end.flatten.join
   end

--- a/lib/comfortable_mexican_sofa/content/renderer.rb
+++ b/lib/comfortable_mexican_sofa/content/renderer.rb
@@ -54,7 +54,7 @@ class ComfortableMexicanSofa::Content::Renderer
       raise Error, "Deep tag nesting or recursive nesting detected"
     end
 
-    nodes.map do |node|
+    result = nodes.map do |node|
       case node
       when String
         sanitize_erb(node, allow_erb)
@@ -64,6 +64,8 @@ class ComfortableMexicanSofa::Content::Renderer
         render(nodes, allow_erb || node.allow_erb?)
       end
     end.flatten.join
+    @depth -= 1
+    result
   end
 
   def sanitize_erb(string, allow_erb)

--- a/test/lib/content/renderer_test.rb
+++ b/test/lib/content/renderer_test.rb
@@ -268,9 +268,12 @@ class ContentRendererTest < ActiveSupport::TestCase
   end
 
   def test_render_with_more_than_hundred_tags
-    test_string = Array.new(101) { "{{cms:text content}}" }.join(" ")
+    test_string =
+      Array.new(ComfortableMexicanSofa::Content::Renderer::MAX_DEPTH) { "{{cms:text content}}" }.join(" ")
     out = render_string(test_string)
-    assert_equal Array.new(101) { "content" }.join(" "), out
+    expected =
+      Array.new(ComfortableMexicanSofa::Content::Renderer::MAX_DEPTH) { "content" }.join(" ")
+    assert_equal expected, out
   end
 
   def test_render_stack_overflow

--- a/test/lib/content/renderer_test.rb
+++ b/test/lib/content/renderer_test.rb
@@ -267,6 +267,12 @@ class ContentRendererTest < ActiveSupport::TestCase
     assert_equal "a c e <%= test() %> f d b", out
   end
 
+  def test_render_with_more_than_hundred_tags
+    test_string = Array.new(101) { "{{cms:text content}}" }.join(" ")
+    out = render_string(test_string)
+    assert_equal Array.new(101) { "content" }.join(" "), out
+  end
+
   def test_render_stack_overflow
     # making self-referencing content loop here
     comfy_cms_snippets(:default).update_column(:content, "a {{cms:snippet default}} b")


### PR DESCRIPTION
When page has more than 101 tag it can't be rendered because of "Deep tag nesting or recursive nesting detected" will be raised.
For solve this problem we can decrement `@depth` counter after rendering of each tag. 
In this case exception will be removed for pages with hundreds of tags, but we still able to catch stack overflow. 