### PR TITLE
Set rails limit version to less than 6.1.0

### DIFF
--- a/comfortable_mexican_sofa.gemspec
+++ b/comfortable_mexican_sofa.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "kramdown",              ">= 1.0.0"
   s.add_dependency "mimemagic",             ">= 0.3.2"
   s.add_dependency "mini_magick",           ">= 4.8.0"
-  s.add_dependency "rails",                 ">= 5.2.0"
+  s.add_dependency "rails",                 ">= 5.2.0", "< 6.1.0"
   s.add_dependency "rails-i18n",            ">= 5.0.0"
   s.add_dependency "sassc-rails",           ">= 2.0.0"
 end

--- a/test/gemfiles/6.0.gemfile
+++ b/test/gemfiles/6.0.gemfile
@@ -4,7 +4,7 @@ source "http://rubygems.org"
 
 gemspec path: "../../"
 
-gem "rails", ">= 6.0"
+gem "rails", ">= 6.0", "< 6.1"
 
 group :development, :test do
   gem "byebug",             "~> 10.0.0", platforms: %i[mri mingw x64_mingw]


### PR DESCRIPTION
https://travis-ci.org/github/comfy/comfortable-mexican-sofa/builds/764633623 ( https://github.com/comfy/comfortable-mexican-sofa/pull/927 )

The above CI has failed.
In order to fix this, it seems necessary to support https://github.com/rails/rails/pull/34935 added in rails 6.1: https://github.com/comfy/comfortable-mexican-sofa/issues/929
However, as a first aid, I set rails limit version to less than 6.1.0.