### PR TITLE
Worked only when IDs are integers, but not when UUIDs

### DIFF
--- a/lib/comfortable_mexican_sofa/extensions/has_revisions.rb
+++ b/lib/comfortable_mexican_sofa/extensions/has_revisions.rb
@@ -53,8 +53,8 @@ module ComfortableMexicanSofa::HasRevisions
       end
 
       # blowing away old revisions
-      ids = [0] + revisions.order(created_at: :desc).limit(limit).pluck(:id)
-      revisions.where("id NOT IN (?)", ids).destroy_all
+      ids = revisions.order(created_at: :desc).limit(limit).pluck(:id)
+      revisions.where.not(id: ids).destroy_all
     end
 
     # Assigning whatever is found in revision data and attempting to save the object


### PR DESCRIPTION
Previous operation when IDs were UUID:
ActiveRecord::StatementInvalid (PG::UndefinedFunction: ERROR:  operator does not exist: uuid <> integer)

New operation:
Success!

### Summary

General information about what this PR is all about. If it fixes any issues
please don't forget to tag them.

Thanks for contributing!
