### PR TITLE
Ruby 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ rvm:
   - 2.4.9
   - 2.5.7
   - 2.6.5
+  - 3.0.2
 gemfile:
   - test/gemfiles/5.2.gemfile
 jobs:
@@ -21,6 +22,8 @@ jobs:
     - rvm: 2.5.7
       gemfile: test/gemfiles/6.0.gemfile
     - rvm: 2.6.5
+      gemfile: test/gemfiles/6.0.gemfile
+    - rvm: 3.0.2
       gemfile: test/gemfiles/6.0.gemfile
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,21 +10,12 @@ addons:
 
 language: ruby
 rvm:
-  - 2.3.8
-  - 2.4.9
-  - 2.5.7
-  - 2.6.5
+  - 2.6.8
+  - 2.7.4
   - 3.0.2
 gemfile:
   - test/gemfiles/5.2.gemfile
-jobs:
-  include:
-    - rvm: 2.5.7
-      gemfile: test/gemfiles/6.0.gemfile
-    - rvm: 2.6.5
-      gemfile: test/gemfiles/6.0.gemfile
-    - rvm: 3.0.2
-      gemfile: test/gemfiles/6.0.gemfile
+  - test/gemfiles/6.0.gemfile
 branches:
   only:
     - master

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,9 @@ source "http://rubygems.org"
 gemspec
 
 group :development, :test do
-  gem "autoprefixer-rails", "~> 8.1.0"
+  gem "autoprefixer-rails", ">= 8.1.0"
   gem "byebug",             "~> 10.0.0", platforms: %i[mri mingw x64_mingw]
-  gem "capybara",           "~> 2.17.0"
+  gem "capybara",           ">= 2.17.0"
   gem "kaminari",           "~> 1.1.1"
   gem "puma",               "~> 3.12.2"
   gem "rubocop",            "~> 0.55.0", require: false
@@ -16,7 +16,7 @@ group :development, :test do
 end
 
 group :development do
-  gem "listen",       "~> 3.1.5"
+  gem "listen",       "~> 3.1"
   gem "web-console",  "~> 3.5.1"
 end
 

--- a/lib/comfortable_mexican_sofa/routing.rb
+++ b/lib/comfortable_mexican_sofa/routing.rb
@@ -5,8 +5,8 @@ require_relative "routes/cms"
 
 class ActionDispatch::Routing::Mapper
 
-  def comfy_route(identifier, options = {})
-    send("comfy_route_#{identifier}", options)
+  def comfy_route(identifier, **options)
+    send("comfy_route_#{identifier}", **options)
   end
 
 end


### PR DESCRIPTION
This pull request adds Ruby 3 to the test suite and relaxes some test and development dependencies to get the tests to run.

It also removes Ruby 2.3, 2.4, and 2.5 from the test suite, which are officially EOL.

This supersedes #937, which includes the fix for splatting of keyword arguments.